### PR TITLE
fix: remove @astrojs/tailwind (incompatible with Astro v6), use PostC…

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,6 @@
       "version": "1.0.0",
       "dependencies": {
         "@astrojs/sitemap": "^3.7.1",
-        "@astrojs/tailwind": "^6.0.2",
         "astro": "^6.0.4",
         "autoprefixer": "^10.4.27",
         "tailwindcss": "^3.4.19"
@@ -91,21 +90,6 @@
         "sitemap": "^9.0.0",
         "stream-replace-string": "^2.0.0",
         "zod": "^4.3.6"
-      }
-    },
-    "node_modules/@astrojs/tailwind": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/@astrojs/tailwind/-/tailwind-6.0.2.tgz",
-      "integrity": "sha512-j3mhLNeugZq6A8dMNXVarUa8K6X9AW+QHU9u3lKNrPLMHhOQ0S7VeWhHwEeJFpEK1BTKEUY1U78VQv2gN6hNGg==",
-      "license": "MIT",
-      "dependencies": {
-        "autoprefixer": "^10.4.21",
-        "postcss": "^8.5.3",
-        "postcss-load-config": "^4.0.2"
-      },
-      "peerDependencies": {
-        "astro": "^3.0.0 || ^4.0.0 || ^5.0.0",
-        "tailwindcss": "^3.0.24"
       }
     },
     "node_modules/@astrojs/telemetry": {

--- a/package.json
+++ b/package.json
@@ -10,7 +10,6 @@
   },
   "dependencies": {
     "@astrojs/sitemap": "^3.7.1",
-    "@astrojs/tailwind": "^6.0.2",
     "astro": "^6.0.4",
     "autoprefixer": "^10.4.27",
     "tailwindcss": "^3.4.19"


### PR DESCRIPTION
…SS directly

Tailwind CSS is already configured via postcss.config.mjs — the @astrojs/tailwind integration was leftover and caused npm ci to fail in CI due to peer dependency conflict with Astro v6.

https://claude.ai/code/session_01AQ88R452HPtq97J3583XUM