### PR TITLE
feat: update experience & talks, add recruiter-focused CV page

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,5 @@
+node_modules
+dist
+.git
+.github
+.astro

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,8 @@ jobs:
 
       - name: Build Astro site
         run: npm run build
+        env:
+          PUBLIC_GA_ID: ${{ secrets.PUBLIC_GA_ID }}
 
       - uses: actions/upload-pages-artifact@v3
         with:

--- a/Claude.md
+++ b/Claude.md
@@ -54,8 +54,14 @@ Follow conventional commit format:
 
 Example: `feat: add dark mode toggle to settings`
 
+**Author**: Always set the commit author to the AI model being used:
+```bash
+git commit --author="Claude Sonnet <claude-sonnet@anthropic.com>" -m "..."
+```
+
 ## Project-Specific Notes
 
 - This is an Astro-based personal website hosted on GitHub Pages
 - Profile images are stored in `/public/` directory
 - Main page is at `src/pages/index.astro`
+- **Language**: All user-facing content (titles, labels, descriptions) must be in **English**, even if the original talk/event was given in Spanish. Translate any Spanish titles before adding them to the site.

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,6 +14,16 @@ RUN npm run build
 # ── Stage 2: serve ───────────────────────────────────────────────────────────
 FROM nginx:alpine AS server
 
+# Add custom nginx config to handle directories without trailing slashes
+RUN echo 'server { \
+    listen 80; \
+    location / { \
+        root /usr/share/nginx/html; \
+        index index.html index.htm; \
+        try_files $uri $uri/ $uri.html =404; \
+    } \
+}' > /etc/nginx/conf.d/default.conf
+
 # Copy built static files into nginx's default serve directory
 COPY --from=builder /app/dist /usr/share/nginx/html
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,23 @@
+# ── Stage 1: build ───────────────────────────────────────────────────────────
+FROM node:22-alpine AS builder
+
+WORKDIR /app
+
+# Install dependencies first (layer-cached unless package.json changes)
+COPY package.json package-lock.json* ./
+RUN npm install
+
+# Copy source and build the static site
+COPY . .
+RUN npm run build
+
+# ── Stage 2: serve ───────────────────────────────────────────────────────────
+FROM nginx:alpine AS server
+
+# Copy built static files into nginx's default serve directory
+COPY --from=builder /app/dist /usr/share/nginx/html
+
+# Expose port 80
+EXPOSE 80
+
+CMD ["nginx", "-g", "daemon off;"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,5 @@
+services:
+  web:
+    build: .
+    ports:
+      - "4321:80"

--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -40,6 +40,17 @@ const year = new Date().getFullYear();
             <path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-5.214-6.817L4.99 21.75H1.68l7.73-8.835L1.254 2.25H8.08l4.713 6.231zm-1.161 17.52h1.833L7.084 4.126H5.117z" />
           </svg>
         </a>
+        <a
+          href="https://medium.com/@matesanz.cuadrado"
+          target="_blank"
+          rel="noopener noreferrer"
+          class="text-gray-500 hover:text-black transition-colors"
+          aria-label="Medium"
+        >
+          <svg class="w-5 h-5" fill="currentColor" viewBox="0 0 24 24">
+            <path d="M13.54 12a6.8 6.8 0 11-6.77-6.82A6.77 6.77 0 0113.54 12zm7.42 0c0 3.54-1.51 6.42-3.38 6.42S14.2 15.54 14.2 12s1.51-6.42 3.38-6.42 3.38 2.88 3.38 6.42zm3.04 0c0 3.25-.31 5.88-.7 5.88s-.7-2.63-.7-5.88.31-5.88.7-5.88.7 2.63.7 5.88z" />
+          </svg>
+        </a>
       </div>
 
       <!-- Copyright -->

--- a/src/components/Nav.astro
+++ b/src/components/Nav.astro
@@ -3,6 +3,7 @@ const navLinks = [
   { href: '/', label: 'Home' },
   { href: '/education', label: 'Education' },
   { href: '/experience', label: 'Experience' },
+  { href: '/projects', label: 'Projects' },
   { href: '/talks', label: 'Talks' },
   { href: '/cv', label: 'CV' },
 ];

--- a/src/components/Nav.astro
+++ b/src/components/Nav.astro
@@ -4,6 +4,7 @@ const navLinks = [
   { href: '/education', label: 'Education' },
   { href: '/experience', label: 'Experience' },
   { href: '/talks', label: 'Talks' },
+  { href: '/cv', label: 'CV' },
 ];
 
 const pathname = Astro.url.pathname;

--- a/src/components/Nav.astro
+++ b/src/components/Nav.astro
@@ -5,6 +5,7 @@ const navLinks = [
   { href: '/experience', label: 'Experience' },
   { href: '/projects', label: 'Projects' },
   { href: '/talks', label: 'Talks' },
+  { href: '/technologies', label: 'Technologies' },
   { href: '/cv', label: 'CV' },
 ];
 

--- a/src/components/Nav.astro
+++ b/src/components/Nav.astro
@@ -4,8 +4,8 @@ const navLinks = [
   { href: '/education', label: 'Education' },
   { href: '/experience', label: 'Experience' },
   { href: '/projects', label: 'Projects' },
-  { href: '/talks', label: 'Talks' },
   { href: '/technologies', label: 'Technologies' },
+  { href: '/talks', label: 'Talks' },
   { href: '/cv', label: 'CV' },
 ];
 

--- a/src/components/SkillBadges.astro
+++ b/src/components/SkillBadges.astro
@@ -20,6 +20,16 @@ const categories = [
       { label: 'TensorFlow', url: 'https://img.shields.io/badge/TensorFlow-%23FF6F00.svg?style=for-the-badge&logo=TensorFlow&logoColor=white' },
       { label: 'Keras', url: 'https://img.shields.io/badge/Keras-%23D00000.svg?style=for-the-badge&logo=Keras&logoColor=white' },
       { label: 'PyTorch', url: 'https://img.shields.io/badge/PyTorch-%23EE4C2C.svg?style=for-the-badge&logo=PyTorch&logoColor=white' },
+      { label: 'OpenAI', url: 'https://img.shields.io/badge/OpenAI-%23412991.svg?style=for-the-badge&logo=openai&logoColor=white' },
+      { label: 'Claude', url: 'https://img.shields.io/badge/Claude-D97757?style=for-the-badge&logo=anthropic&logoColor=white' },
+    ],
+  },
+  {
+    name: 'Automation & Low-Code',
+    badges: [
+      { label: 'n8n', url: 'https://img.shields.io/badge/n8n-FF6D5A?style=for-the-badge&logo=n8n&logoColor=white' },
+      { label: 'Make.com', url: 'https://img.shields.io/badge/Make.com-8027f8?style=for-the-badge&logo=make&logoColor=white' },
+      { label: 'Airtable', url: 'https://img.shields.io/badge/Airtable-18BFFF?style=for-the-badge&logo=airtable&logoColor=white' },
     ],
   },
   {
@@ -73,7 +83,10 @@ const categories = [
       { label: 'PyCharm', url: 'https://img.shields.io/badge/pycharm-143?style=for-the-badge&logo=pycharm&logoColor=black&color=black&labelColor=green' },
       { label: 'VS Code', url: 'https://img.shields.io/badge/Visual%20Studio%20Code-0078d7.svg?style=for-the-badge&logo=visual-studio-code&logoColor=white' },
       { label: 'Jira', url: 'https://img.shields.io/badge/jira-%230A0FFF.svg?style=for-the-badge&logo=jira&logoColor=white' },
+      { label: 'Confluence', url: 'https://img.shields.io/badge/confluence-%23172B4D.svg?style=for-the-badge&logo=confluence&logoColor=white' },
       { label: 'Postman', url: 'https://img.shields.io/badge/Postman-FF6C37?style=for-the-badge&logo=postman&logoColor=white' },
+      { label: 'Medium', url: 'https://img.shields.io/badge/Medium-12100E?style=for-the-badge&logo=medium&logoColor=white' },
+      { label: 'OpenCode', url: 'https://img.shields.io/badge/OpenCode-000000?style=for-the-badge&logo=github&logoColor=white' },
     ],
   },
 ];

--- a/src/components/TimelineEntry.astro
+++ b/src/components/TimelineEntry.astro
@@ -2,11 +2,12 @@
 interface Props {
   title: string;
   subtitle: string;
+  subtitleUrl?: string;
   period: string;
   description?: string;
 }
 
-const { title, subtitle, period, description } = Astro.props;
+const { title, subtitle, subtitleUrl, period, description } = Astro.props;
 ---
 
 <div class="relative pl-10 pb-8">
@@ -20,7 +21,13 @@ const { title, subtitle, period, description } = Astro.props;
       <h3 class="text-lg font-semibold text-gray-900">{title}</h3>
       <span class="text-sm text-indigo-600 font-medium whitespace-nowrap">{period}</span>
     </div>
-    <p class="text-sm font-medium text-gray-500 mb-3">{subtitle}</p>
+    {subtitleUrl ? (
+      <p class="text-sm font-medium text-gray-500 mb-3">
+        <a href={subtitleUrl} target="_blank" rel="noopener noreferrer" class="hover:text-indigo-600 transition-colors">{subtitle}</a>
+      </p>
+    ) : (
+      <p class="text-sm font-medium text-gray-500 mb-3">{subtitle}</p>
+    )}
     {description && (
       <p class="text-sm text-gray-700 leading-relaxed">{description}</p>
     )}

--- a/src/data/projects.ts
+++ b/src/data/projects.ts
@@ -1,0 +1,298 @@
+export interface ProjectLink {
+  label: string;
+  url: string;
+  type: 'primary' | 'outline';
+}
+
+export interface Project {
+  id: string;
+  title: string;
+  emoji: string;
+  description: string;
+  /** Matches the #anchor id used in experience.astro */
+  companyId: string;
+  /** Display label shown as a tag on the project card */
+  company: string;
+  period: string;
+  links?: ProjectLink[];
+}
+
+/**
+ * Single source of truth for all projects.
+ * Ordered newest first.
+ * Both /projects and /experience import from here — do not duplicate content elsewhere.
+ */
+export const projects: Project[] = [
+  // ── Labster ──────────────────────────────────────────────────────────────
+  {
+    id: 'labster-automation',
+    title: 'AI Course Automation System',
+    emoji: '⚡',
+    description:
+      'Labster produces VR/3D interactive science simulations for universities and high schools — ' +
+      'immersive and high-quality, but expensive to build. I redesigned the internal course-creation ' +
+      'process end-to-end using AI and low-code automation: Airtable as the structured data backbone, ' +
+      'n8n as the workflow engine, and Claude + OpenAI as the AI layer. The result cut course ' +
+      'development time by 90%, making each simulation dramatically faster and cheaper to produce ' +
+      'without sacrificing educational quality. I also built tailored AI-assisted workflows for ' +
+      'Learning Experts and Subject Matter Experts — covering learning objectives, driving questions, ' +
+      "Bloom's taxonomy levels, and Simpson's skill levels — bridging cutting-edge AI with sound " +
+      'pedagogical frameworks.',
+    companyId: 'labster',
+    company: 'Labster',
+    period: 'Apr 2025 – Present',
+  },
+
+  // ── Freelance ─────────────────────────────────────────────────────────────
+  {
+    id: 'video-movement-prediction',
+    title: 'Video Movement Prediction Model',
+    emoji: '🎥',
+    description:
+      'Designed and trained a PyTorch-based deep learning model for video movement prediction — ' +
+      'from architecture design and dataset preparation through to training and evaluation. ' +
+      '(NDA — further details confidential.)',
+    companyId: 'freelance',
+    company: 'Freelance',
+    period: 'Mar – Jun 2025',
+  },
+
+  // ── SNGULAR ───────────────────────────────────────────────────────────────
+  {
+    id: 'santander-ai-mvp',
+    title: 'Banco Santander — Internal AI MVP',
+    emoji: '🏦',
+    description:
+      'Designed an MVP concept for safe, scalable internal AI adoption at one of the world\'s ' +
+      'largest financial institutions. Researched and synthesized how leading global companies ' +
+      'govern AI internally — policies, tooling, access control, audit trails — and translated ' +
+      'those patterns into an actionable, enterprise-ready proposal tailored to Banco Santander\'s ' +
+      'specific constraints and culture.',
+    companyId: 'sngular',
+    company: 'SNGULAR',
+    period: 'Dec 2024 – Mar 2025',
+  },
+  {
+    id: 'real-estate-ai',
+    title: 'Real Estate Document Analysis Platform',
+    emoji: '🏠',
+    description:
+      'Built an end-to-end AI pipeline that ingested legal and technical property documents ' +
+      '(contracts, cadastral records, technical reports) and extracted structured data into a ' +
+      'relational database. The system replaced manual expert review — previously a bottleneck ' +
+      'of hours per property — with automated analysis running in minutes, enabling fast and ' +
+      'consistent real estate due diligence at scale.',
+    companyId: 'sngular',
+    company: 'SNGULAR',
+    period: '2024',
+  },
+  {
+    id: 'embassy-basketball-ai',
+    title: 'The Embassy — Real-Time Basketball AI',
+    emoji: '🏀',
+    description:
+      'Developed a real-time AI basketball match evaluation tool for The Embassy, the academy ' +
+      'run by KM Calderón — Spanish NBA champion and former NBA player. The system used ' +
+      'computer vision to track players and the ball live on court, feeding a dashboard of ' +
+      'performance analytics: shot detection, player positioning heatmaps, and match statistics. ' +
+      'Designed to run in real time during training sessions with no manual tagging required.',
+    companyId: 'sngular',
+    company: 'SNGULAR',
+    period: 'Summer 2023',
+    links: [
+      {
+        label: 'The Embassy',
+        url: 'https://en.wikipedia.org/wiki/Carlos_Jim%C3%A9nez_Calder%C3%B3n',
+        type: 'outline',
+      },
+    ],
+  },
+  {
+    id: 'padmi-startup',
+    title: 'PADMI — 3D Padel Analytics Startup',
+    emoji: '🎾',
+    description:
+      'Six-month intensive sprint: built the initial AI system from scratch and launched a fully ' +
+      'working prototype for 3D computer vision padel performance analysis. PADMI went from zero ' +
+      'to a demo-ready product using multi-camera 3D tracking, pose estimation, and biomechanical ' +
+      'metrics. The system analysed player technique, shot speed, and court coverage in real time. ' +
+      'Responsible for the full AI stack: camera calibration, stereo reconstruction, model ' +
+      'training, and the analytics pipeline.',
+    companyId: 'sngular',
+    company: 'SNGULAR',
+    period: 'Jan – Jul 2023',
+    links: [
+      { label: '🌐 padmi.es', url: 'https://www.padmi.es/', type: 'primary' },
+    ],
+  },
+  {
+    id: 'mercadona-cashierless',
+    title: 'Mercadona — Cashierless Store MVP',
+    emoji: '🛒',
+    description:
+      "Developed a cashierless retail store MVP for Mercadona Tech, Spain's largest supermarket " +
+      'chain. The system used 3D computer vision and AI to track customers and products throughout ' +
+      'the store — detecting what items are picked up or put back, and automating the checkout ' +
+      'process entirely. Key challenges included multi-person tracking under occlusion, real-time ' +
+      'inference on in-store hardware, and handling the combinatorial complexity of a full product ' +
+      'catalogue.',
+    companyId: 'sngular',
+    company: 'SNGULAR',
+    period: 'Mar – Dec 2022',
+  },
+
+  // ── Codespace Academy ─────────────────────────────────────────────────────
+  {
+    id: 'codespace-bootcamp',
+    title: 'ML Bootcamp Curriculum',
+    emoji: '🎓',
+    description:
+      'Designed and delivered the full Machine Learning curriculum for Codespace Academy\'s ' +
+      'bootcamp cohorts. Covers Python fundamentals through advanced ML: supervised and ' +
+      'unsupervised learning, deep learning with PyTorch and TensorFlow, model evaluation, ' +
+      'and MLOps best practices — experiment tracking with MLflow, containerisation with Docker, ' +
+      'CI/CD pipelines, and model serving. Each cohort goes from zero to deploying a real ML ' +
+      'model in production.',
+    companyId: 'codespace',
+    company: 'Codespace Academy',
+    period: 'May 2023 – Present',
+  },
+
+  // ── Aeorum ────────────────────────────────────────────────────────────────
+  {
+    id: 'aeorum-drone-cv',
+    title: 'Drone Computer Vision Platform',
+    emoji: '🚁',
+    description:
+      'Built the computer vision platform powering Aeorum\'s drone fleet for agricultural ' +
+      'and renewable energy inspection. Implemented aerial object detection and tracking using ' +
+      'YOLO and SSD-MobileNet, deployed on both GPU servers and embedded systems (C++, Docker, ' +
+      'ROS). Developed a proprietary pipeline for generating multispectral GeoTIFFs from ' +
+      'multiple aerial cameras — enabling agronomists to assess crop health via wavelength ' +
+      'orthomosaics. Also built a thermal anomaly detection system for photovoltaic panel ' +
+      'inspection, and a Structure from Motion pipeline producing 3D point clouds from 2D ' +
+      'drone image sequences.',
+    companyId: 'aeorum',
+    company: 'Aeorum',
+    period: 'Sept 2020 – Mar 2022',
+  },
+
+  // ── University of Malaga ──────────────────────────────────────────────────
+  {
+    id: 'dias2p-streetqr',
+    title: 'DIAS2P / StreetQR — Pedestrian Safety System',
+    emoji: '🚦',
+    description:
+      'Part of the Smart-Campus I research projects at the University of Malaga. Built an ' +
+      'embedded computer vision system that attached to traffic signs and detected pedestrians ' +
+      'in real time, triggering audio and visual warnings to alert drivers — reducing the risk ' +
+      'of car-pedestrian collisions. Used YOLO, SSD-MobileNet, and Mask-RCNN running on a ' +
+      'Jetson Nano, with Hungarian Algorithm-based object tracking. Also designed the electronic ' +
+      'actuator architecture (lights and sound) and built a Firebase API to log crossing ' +
+      'statistics. Research published at CIPI 2019.',
+    companyId: 'uma',
+    company: 'Univ. Malaga',
+    period: 'Dec 2018 – Mar 2020',
+    links: [
+      { label: '📄 CIPI 2019 Paper', url: 'https://riuma.uma.es/xmlui/bitstream/handle/10630/18443/CIPI_2019_paper_37.pdf', type: 'primary' },
+      { label: '💻 DIAS2P', url: 'https://github.com/Matesanz/DIAS2P', type: 'outline' },
+      { label: '💻 StreetQR', url: 'https://github.com/Matesanz/StreetQR', type: 'outline' },
+    ],
+  },
+
+  // ── Monkeat ───────────────────────────────────────────────────────────────
+  {
+    id: 'monkeat-pwa',
+    title: 'Monkeat — Live Marketplace PWA',
+    emoji: '🕵️',
+    description:
+      'Co-founded Monkeat, a real-time marketplace helping pubs boost customer acquisition ' +
+      'through live offers during off-peak hours. As CTO, designed the full system architecture ' +
+      'and built the Progressive Web App from scratch using Vue + Ionic on the frontend, ' +
+      'MongoDB for the database, Flask for the backend API, and Firebase for real-time updates ' +
+      'and authentication. Developed inside the Demium incubation program. We could not ' +
+      'ultimately validate the MVP and closed the project after a few months — but shipping a ' +
+      'full-stack product as a first-time CTO was an invaluable experience.',
+    companyId: 'monkeat',
+    company: 'Monkeat',
+    period: 'Mar – Oct 2019',
+  },
+
+  // ── Side Projects ─────────────────────────────────────────────────────────
+  {
+    id: 'mri-superresolution',
+    title: 'MRI Super-Resolution with GANs',
+    emoji: '🧠',
+    description:
+      'Master\'s thesis project (graduated with honors): developed a 3D MRI super-resolution ' +
+      'model using Generative Adversarial Networks (WGAN-GP), achieving a 4× improvement in ' +
+      'image quality. The model learned to reconstruct high-resolution volumetric MRI scans ' +
+      'from low-resolution inputs, with potential applications in reducing scan time and ' +
+      'improving diagnostic quality in resource-constrained settings.',
+    companyId: 'side',
+    company: 'Side Project',
+    period: '2019 – 2020',
+    links: [
+      { label: '📄 Thesis', url: 'https://1drv.ms/b/s!AgDuqWQZkjwxj79zyt5colGiRdNT1g?e=1cslcH', type: 'primary' },
+      { label: '💻 Code', url: 'https://github.com/Matesanz/WGAN-GP_MRI_Super_Resolution', type: 'outline' },
+    ],
+  },
+  {
+    id: 'face-expression-recognition',
+    title: 'Face Expression Recognition',
+    emoji: '😄',
+    description:
+      'End-to-end facial expression recognition pipeline: face keypoint detection for data ' +
+      'acquisition, geometric normalization to suppress head rotation, manual labeling of six ' +
+      'expression classes (normal, angry, happy, sad, surprised, winking), k-NN classifier ' +
+      'training, and live webcam inference. Deployed as an interactive Streamlit app — anyone ' +
+      'in the audience could test it live during the talk.',
+    companyId: 'side',
+    company: 'Side Project',
+    period: '2022',
+    links: [
+      { label: '🚀 Live Demo', url: 'https://share.streamlit.io/matesanz/face-expression-recognition/main/app/main.py', type: 'primary' },
+      { label: '💻 Code', url: 'https://github.com/Matesanz/face-expression-recognition', type: 'outline' },
+    ],
+  },
+  {
+    id: 'pet-detector',
+    title: 'Pet Detector with YOLOv3',
+    emoji: '🐈',
+    description:
+      'Custom YOLOv3 object detection model trained from scratch to recognise a specific cat ' +
+      '(Mocka 😂). Used the ImageAI library inside a Jupyter Notebook, covering the full ' +
+      'pipeline: collecting hundreds of photos, annotating bounding boxes, training, and ' +
+      'validating with the mAP metric. Presented live at TabularConf 2021, my first national ' +
+      'conference.',
+    companyId: 'side',
+    company: 'Side Project',
+    period: '2021',
+    links: [
+      { label: '▶ Watch Talk', url: 'https://www.youtube.com/watch?v=Fr8t0SuHASA', type: 'primary' },
+      { label: '💻 Code', url: 'https://github.com/Matesanz/pet-detector', type: 'outline' },
+    ],
+  },
+  {
+    id: 'malaga-ai-association',
+    title: 'Málaga AI Association',
+    emoji: '🧠',
+    description:
+      'Co-founded the Málaga chapter of the Spain AI Association — a community for sharing ' +
+      'knowledge about Artificial Intelligence through talks, workshops, and courses. ' +
+      'Organised and delivered multiple events including bootcamps, meetups, and online courses ' +
+      'that reached up to 200 students per session. The association is still active and ' +
+      'continues to grow the local AI community.',
+    companyId: 'side',
+    company: 'Side Project',
+    period: '2018 – Present',
+    links: [
+      { label: '🐦 Twitter', url: 'https://twitter.com/aimalaga', type: 'outline' },
+    ],
+  },
+];
+
+/** Returns all projects belonging to a given companyId, preserving array order (newest first). */
+export function getProjectsByCompany(companyId: string): Project[] {
+  return projects.filter((p) => p.companyId === companyId);
+}

--- a/src/data/projects.ts
+++ b/src/data/projects.ts
@@ -19,11 +19,26 @@ export interface Project {
 
 /**
  * Single source of truth for all projects.
- * Ordered newest first.
+ * Ordered newest first by START date.
  * Both /projects and /experience import from here — do not duplicate content elsewhere.
  */
 export const projects: Project[] = [
-  // ── Labster ──────────────────────────────────────────────────────────────
+  // ── 2026 ──────────────────────────────────────────────────────────────
+  {
+    id: 'labster-accessibility-ai',
+    title: 'AI Simulation Accessibility Uplift',
+    emoji: '♿',
+    description:
+      'Developing an AI-driven system to automatically uplift legacy VR/3D simulations for web accessibility. ' +
+      'The system analyzes legacy code and assets to inject ARIA readout text, descriptive tooltips, ' +
+      'smart autocompletes, and keyboard-navigable paths. This ensures hundreds of specialized science ' +
+      'simulations meet modern accessibility standards without requiring manual per-simulation refactoring.',
+    companyId: 'labster',
+    company: 'Labster',
+    period: 'Feb 2026 – Present',
+  },
+
+  // ── 2025 ──────────────────────────────────────────────────────────────
   {
     id: 'labster-automation',
     title: 'AI Course Automation System',
@@ -40,10 +55,8 @@ export const projects: Project[] = [
       'pedagogical frameworks.',
     companyId: 'labster',
     company: 'Labster',
-    period: 'Apr 2025 – Present',
+    period: 'Apr 2025 – Jan 2026',
   },
-
-  // ── Freelance ─────────────────────────────────────────────────────────────
   {
     id: 'video-movement-prediction',
     title: 'Video Movement Prediction Model',
@@ -54,10 +67,10 @@ export const projects: Project[] = [
       '(NDA — further details confidential.)',
     companyId: 'freelance',
     company: 'Freelance',
-    period: 'Mar – Jun 2025',
+    period: 'Mar 2025 – Jun 2025',
   },
 
-  // ── SNGULAR ───────────────────────────────────────────────────────────────
+  // ── 2024 ──────────────────────────────────────────────────────────────
   {
     id: 'santander-ai-mvp',
     title: 'Banco Santander — Internal AI MVP',
@@ -73,18 +86,66 @@ export const projects: Project[] = [
     period: 'Dec 2024 – Mar 2025',
   },
   {
+    id: 'uve-valuation-ai',
+    title: 'AI Automated Property Valuation',
+    emoji: '📸',
+    description:
+      'Developed an AI system to estimate property costs by analyzing interior photos. ' +
+      'Used image embeddings to train custom Machine Learning models that automatically ' +
+      'rated the state of specific rooms (from 0 to 1). The system compared these ratings ' +
+      'against an internal valuation database to provide objective, data-driven cost estimates.',
+    companyId: 'sngular',
+    company: 'UVE Valoraciones',
+    period: 'Aug 2024 – Dec 2024',
+    links: [
+      { label: '🌐 v-valoraciones.com', url: 'https://v-valoraciones.com/', type: 'primary' },
+    ],
+  },
+  {
     id: 'real-estate-ai',
     title: 'Real Estate Document Analysis Platform',
     emoji: '🏠',
     description:
-      'Built an end-to-end AI pipeline that ingested legal and technical property documents ' +
-      '(contracts, cadastral records, technical reports) and extracted structured data into a ' +
-      'relational database. The system replaced manual expert review — previously a bottleneck ' +
-      'of hours per property — with automated analysis running in minutes, enabling fast and ' +
-      'consistent real estate due diligence at scale.',
+      'Built an end-to-end AI pipeline for UVE Valoraciones that ingested legal and technical ' +
+      'property documents (contracts, cadastral records, technical reports) and extracted ' +
+      'structured data into a relational database. The system replaced manual expert review, ' +
+      'enabling fast and consistent real estate due diligence at scale.',
     companyId: 'sngular',
-    company: 'SNGULAR',
-    period: '2024',
+    company: 'UVE Valoraciones',
+    period: 'Jan 2024 – Jul 2024',
+    links: [
+      { label: '🌐 v-valoraciones.com', url: 'https://v-valoraciones.com/', type: 'primary' },
+    ],
+  },
+
+  // ── 2023 ──────────────────────────────────────────────────────────────
+  {
+    id: 'junction-2023-rag',
+    title: 'Knowledge Graph Visualization & RAG',
+    emoji: '🌐',
+    description:
+      'Participated in Helsinki International Junction 2023 among 1,000 international participants. ' +
+      'Developed an internal knowledge graph visualization system (similar to Obsidian) using a ' +
+      'RAG (Retrieval-Augmented Generation) pipeline for intelligent data exploration.',
+    companyId: 'side',
+    company: 'Side Project',
+    period: 'Nov 2023',
+  },
+  {
+    id: 'junction-malaga-steganography',
+    title: 'Examfy — Image Leak Detection System',
+    emoji: '🔐',
+    description:
+      'Winner of the Local Málaga Junction Hackathon (earning a spot for Helsinki International Junction). ' +
+      'Developed a steganographic system for Examfy to insert hidden tracking codes into school images. ' +
+      'This allowed identifying the source of any leaked materials by tracing back the personal copy ' +
+      'to the original recipient.',
+    companyId: 'side',
+    company: 'Side Project',
+    period: 'Oct 2023',
+    links: [
+      { label: '🚀 Live Demo', url: 'https://snapguard.streamlit.app/', type: 'primary' },
+    ],
   },
   {
     id: 'embassy-basketball-ai',
@@ -98,13 +159,46 @@ export const projects: Project[] = [
       'Designed to run in real time during training sessions with no manual tagging required.',
     companyId: 'sngular',
     company: 'SNGULAR',
-    period: 'Summer 2023',
+    period: 'Jul 2023 – Aug 2023',
     links: [
       {
-        label: 'The Embassy',
-        url: 'https://en.wikipedia.org/wiki/Carlos_Jim%C3%A9nez_Calder%C3%B3n',
-        type: 'outline',
+        label: '🌐 theembassytc.com',
+        url: 'https://www.theembassytc.com/',
+        type: 'primary',
       },
+    ],
+  },
+  {
+    id: 'mlops-cookbook',
+    title: 'MLOps Cookbook',
+    emoji: '👨‍🍳',
+    description:
+      'Designed and delivered a comprehensive MLOps curriculum. Covers the full lifecycle: ' +
+      'experiment tracking with MLflow, containerisation with Docker, CI/CD pipelines for ML, ' +
+      'and model serving. Includes a hands-on "cookbook" repository used by students to master ' +
+      'production-grade Machine Learning workflows.',
+    companyId: 'codespace',
+    company: 'Codespace Academy',
+    period: 'Jan 2023 – Dec 2025',
+    links: [
+      { label: '🚀 Course Web', url: 'https://matesanz.github.io/mlops-cookbook/', type: 'primary' },
+      { label: '💻 Repo', url: 'https://github.com/Matesanz/mlops-cookbook', type: 'outline' },
+    ],
+  },
+  {
+    id: 'python-ml-course',
+    title: 'Python for Machine Learning Cookbook',
+    emoji: '🐍',
+    description:
+      'Core curriculum for Machine Learning fundamentals. From Python basics and data manipulation ' +
+      'with Pandas/NumPy to building and evaluating deep learning models. This course serves as ' +
+      'the technical foundation for bootcamp students entering the AI field.',
+    companyId: 'codespace',
+    company: 'Codespace Academy',
+    period: 'Jan 2023 – Dec 2025',
+    links: [
+      { label: '🚀 Course Web', url: 'https://matesanz.github.io/python-machine-learning-course/', type: 'primary' },
+      { label: '💻 Repo', url: 'https://github.com/Matesanz/python-machine-learning-course', type: 'outline' },
     ],
   },
   {
@@ -114,17 +208,19 @@ export const projects: Project[] = [
     description:
       'Six-month intensive sprint: built the initial AI system from scratch and launched a fully ' +
       'working prototype for 3D computer vision padel performance analysis. PADMI went from zero ' +
-      'to a demo-ready product using multi-camera 3D tracking, pose estimation, and biomechanical ' +
+      'to a demo-ready product using multi-camera 3D tracking, size estimation, and biomechanical ' +
       'metrics. The system analysed player technique, shot speed, and court coverage in real time. ' +
       'Responsible for the full AI stack: camera calibration, stereo reconstruction, model ' +
       'training, and the analytics pipeline.',
     companyId: 'sngular',
     company: 'SNGULAR',
-    period: 'Jan – Jul 2023',
+    period: 'Jan 2023 – Jul 2023',
     links: [
       { label: '🌐 padmi.es', url: 'https://www.padmi.es/', type: 'primary' },
     ],
   },
+
+  // ── 2022 ──────────────────────────────────────────────────────────────
   {
     id: 'mercadona-cashierless',
     title: 'Mercadona — Cashierless Store MVP',
@@ -138,69 +234,107 @@ export const projects: Project[] = [
       'catalogue.',
     companyId: 'sngular',
     company: 'SNGULAR',
-    period: 'Mar – Dec 2022',
+    period: 'Mar 2022 – Dec 2022',
   },
-
-  // ── Codespace Academy ─────────────────────────────────────────────────────
   {
-    id: 'codespace-bootcamp',
-    title: 'ML Bootcamp Curriculum',
-    emoji: '🎓',
+    id: 'face-expression-recognition',
+    title: 'Face Expression Recognition',
+    emoji: '😄',
     description:
-      'Designed and delivered the full Machine Learning curriculum for Codespace Academy\'s ' +
-      'bootcamp cohorts. Covers Python fundamentals through advanced ML: supervised and ' +
-      'unsupervised learning, deep learning with PyTorch and TensorFlow, model evaluation, ' +
-      'and MLOps best practices — experiment tracking with MLflow, containerisation with Docker, ' +
-      'CI/CD pipelines, and model serving. Each cohort goes from zero to deploying a real ML ' +
-      'model in production.',
-    companyId: 'codespace',
-    company: 'Codespace Academy',
-    period: 'May 2023 – Present',
-  },
-
-  // ── Aeorum ────────────────────────────────────────────────────────────────
-  {
-    id: 'aeorum-drone-cv',
-    title: 'Drone Computer Vision Platform',
-    emoji: '🚁',
-    description:
-      'Built the computer vision platform powering Aeorum\'s drone fleet for agricultural ' +
-      'and renewable energy inspection. Implemented aerial object detection and tracking using ' +
-      'YOLO and SSD-MobileNet, deployed on both GPU servers and embedded systems (C++, Docker, ' +
-      'ROS). Developed a proprietary pipeline for generating multispectral GeoTIFFs from ' +
-      'multiple aerial cameras — enabling agronomists to assess crop health via wavelength ' +
-      'orthomosaics. Also built a thermal anomaly detection system for photovoltaic panel ' +
-      'inspection, and a Structure from Motion pipeline producing 3D point clouds from 2D ' +
-      'drone image sequences.',
-    companyId: 'aeorum',
-    company: 'Aeorum',
-    period: 'Sept 2020 – Mar 2022',
-  },
-
-  // ── University of Malaga ──────────────────────────────────────────────────
-  {
-    id: 'dias2p-streetqr',
-    title: 'DIAS2P / StreetQR — Pedestrian Safety System',
-    emoji: '🚦',
-    description:
-      'Part of the Smart-Campus I research projects at the University of Malaga. Built an ' +
-      'embedded computer vision system that attached to traffic signs and detected pedestrians ' +
-      'in real time, triggering audio and visual warnings to alert drivers — reducing the risk ' +
-      'of car-pedestrian collisions. Used YOLO, SSD-MobileNet, and Mask-RCNN running on a ' +
-      'Jetson Nano, with Hungarian Algorithm-based object tracking. Also designed the electronic ' +
-      'actuator architecture (lights and sound) and built a Firebase API to log crossing ' +
-      'statistics. Research published at CIPI 2019.',
-    companyId: 'uma',
-    company: 'Univ. Malaga',
-    period: 'Dec 2018 – Mar 2020',
+      'End-to-end facial expression recognition pipeline: face keypoint detection for data ' +
+      'acquisition, geometric normalization to suppress head rotation, manual labeling of six ' +
+      'expression classes (normal, angry, happy, sad, surprised, winking), k-NN classifier ' +
+      'training, and live webcam inference. Deployed as an interactive Streamlit app — anyone ' +
+      'in the audience could test it live during the talk.',
+    companyId: 'side',
+    company: 'Side Project',
+    period: 'May 2022',
     links: [
-      { label: '📄 CIPI 2019 Paper', url: 'https://riuma.uma.es/xmlui/bitstream/handle/10630/18443/CIPI_2019_paper_37.pdf', type: 'primary' },
-      { label: '💻 DIAS2P', url: 'https://github.com/Matesanz/DIAS2P', type: 'outline' },
-      { label: '💻 StreetQR', url: 'https://github.com/Matesanz/StreetQR', type: 'outline' },
+      { label: '🚀 Live Demo', url: 'https://face-expression-recognition.streamlit.app/', type: 'primary' },
+      { label: '💻 Code', url: 'https://github.com/Matesanz/face-expression-recognition', type: 'outline' },
     ],
   },
 
-  // ── Monkeat ───────────────────────────────────────────────────────────────
+  // ── 2021 ──────────────────────────────────────────────────────────────
+  {
+    id: 'aeorum-embedded-tracking',
+    title: 'Embedded People & Car Tracking',
+    emoji: '🚗',
+    description:
+      'Implemented real-time aerial object detection and tracking (people and vehicles) ' +
+      'using YOLO and SSD-MobileNet. Deployed these models on both GPU servers and ' +
+      'resource-constrained embedded systems on-board drones, ensuring low-latency performance ' +
+      'for critical surveillance and monitoring tasks.',
+    companyId: 'aeorum',
+    company: 'Aeorum',
+    period: 'Dec 2021 – Mar 2022',
+  },
+  {
+    id: 'aeorum-solar-panels',
+    title: 'Autonomous Solar Panel Inspection',
+    emoji: '☀️',
+    description:
+      'Built a thermal anomaly detection system for autonomous photovoltaic panel inspection ' +
+      'using drone imagery. Developed Computer Vision models to identify hotspots and ' +
+      'malfunctions on solar farms, significantly reducing inspection time compared to ' +
+      'manual methods.',
+    companyId: 'aeorum',
+    company: 'Aeorum',
+    period: 'Jul 2021 – Nov 2021',
+  },
+  {
+    id: 'pet-detector',
+    title: 'Pet Detector with YOLOv3',
+    emoji: '🐈',
+    description:
+      'Custom YOLOv3 object detection model trained from scratch to recognise a specific cat ' +
+      '(Mocka 😂). Used the ImageAI library inside a Jupyter Notebook, covering the full ' +
+      'pipeline: collecting hundreds of photos, annotating bounding boxes, training, and ' +
+      'validating with the mAP metric. Presented live at TabularConf 2021, my first national ' +
+      'conference.',
+    companyId: 'side',
+    company: 'Side Project',
+    period: 'Jan 2021',
+    links: [
+      { label: '▶ Watch Talk', url: 'https://www.youtube.com/watch?v=Fr8t0SuHASA', type: 'primary' },
+      { label: '💻 Code', url: 'https://github.com/Matesanz/pet-detector', type: 'outline' },
+    ],
+  },
+
+  // ── 2020 ──────────────────────────────────────────────────────────────
+  {
+    id: 'aeorum-orthophotos',
+    title: 'Multispectral Orthomosaic Pipeline',
+    emoji: '🗺️',
+    description:
+      'Developed a proprietary pipeline for generating high-resolution multispectral GeoTIFFs ' +
+      'from multiple aerial drone cameras. This enabled agronomists to assess crop health via ' +
+      'wavelength orthomosaics. Built using C++, Docker, and ROS to handle large-scale image ' +
+      'stitching and geographic coordinate alignment.',
+    companyId: 'aeorum',
+    company: 'Aeorum',
+    period: 'Sep 2020 – Jul 2021',
+  },
+  {
+    id: 'mri-superresolution',
+    title: 'MRI Super-Resolution with GANs',
+    emoji: '🧠',
+    description:
+      'Master\'s thesis project (graduated with honors): developed a 3D MRI super-resolution ' +
+      'model using Generative Adversarial Networks (WGAN-GP), achieving a 4× improvement in ' +
+      'image quality. The model learned to reconstruct high-resolution volumetric MRI scans ' +
+      'from low-resolution inputs, with potential applications in reducing scan time and ' +
+      'improving diagnostic quality in resource-constrained settings.',
+    companyId: 'side',
+    company: 'Side Project',
+    period: 'Mar 2020 – Jun 2020',
+    links: [
+      { label: '📄 Thesis', url: 'https://1drv.ms/b/s!AgDuqWQZkjwxj79zyt5colGiRdNT1g?e=1cslcH', type: 'primary' },
+      { label: '💻 Code', url: 'https://github.com/Matesanz/WGAN-GP_MRI_Super_Resolution', type: 'outline' },
+    ],
+  },
+
+  // ── 2019 ──────────────────────────────────────────────────────────────
   {
     id: 'monkeat-pwa',
     title: 'Monkeat — Live Marketplace PWA',
@@ -215,62 +349,41 @@ export const projects: Project[] = [
       'full-stack product as a first-time CTO was an invaluable experience.',
     companyId: 'monkeat',
     company: 'Monkeat',
-    period: 'Mar – Oct 2019',
+    period: 'Mar 2019 – Oct 2019',
   },
 
-  // ── Side Projects ─────────────────────────────────────────────────────────
+  // ── 2018 ──────────────────────────────────────────────────────────────
   {
-    id: 'mri-superresolution',
-    title: 'MRI Super-Resolution with GANs',
-    emoji: '🧠',
+    id: 'dias2p',
+    title: 'DIAS2P — Pedestrian Safety System',
+    emoji: '🚦',
     description:
-      'Master\'s thesis project (graduated with honors): developed a 3D MRI super-resolution ' +
-      'model using Generative Adversarial Networks (WGAN-GP), achieving a 4× improvement in ' +
-      'image quality. The model learned to reconstruct high-resolution volumetric MRI scans ' +
-      'from low-resolution inputs, with potential applications in reducing scan time and ' +
-      'improving diagnostic quality in resource-constrained settings.',
-    companyId: 'side',
-    company: 'Side Project',
-    period: '2019 – 2020',
+      'Part of the Smart-Campus I research projects at the University of Malaga. Built an ' +
+      'embedded computer vision system that attached to traffic signs and detected pedestrians ' +
+      'in real time, triggering audio and visual warnings to alert drivers — reducing the risk ' +
+      'of car-pedestrian collisions. Used YOLO, SSD-MobileNet, and Mask-RCNN running on a ' +
+      'Jetson Nano, with Hungarian Algorithm-based object tracking. Research published at CIPI 2019.',
+    companyId: 'uma',
+    company: 'Univ. Malaga',
+    period: 'Dec 2018 – Mar 2020',
     links: [
-      { label: '📄 Thesis', url: 'https://1drv.ms/b/s!AgDuqWQZkjwxj79zyt5colGiRdNT1g?e=1cslcH', type: 'primary' },
-      { label: '💻 Code', url: 'https://github.com/Matesanz/WGAN-GP_MRI_Super_Resolution', type: 'outline' },
+      { label: '📄 CIPI 2019 Paper', url: 'https://riuma.uma.es/xmlui/bitstream/handle/10630/18443/CIPI_2019_paper_37.pdf', type: 'primary' },
+      { label: '💻 DIAS2P', url: 'https://github.com/Matesanz/DIAS2P', type: 'outline' },
     ],
   },
   {
-    id: 'face-expression-recognition',
-    title: 'Face Expression Recognition',
-    emoji: '😄',
+    id: 'streetqr',
+    title: 'StreetQR — Smart Campus Analytics',
+    emoji: '📱',
     description:
-      'End-to-end facial expression recognition pipeline: face keypoint detection for data ' +
-      'acquisition, geometric normalization to suppress head rotation, manual labeling of six ' +
-      'expression classes (normal, angry, happy, sad, surprised, winking), k-NN classifier ' +
-      'training, and live webcam inference. Deployed as an interactive Streamlit app — anyone ' +
-      'in the audience could test it live during the talk.',
-    companyId: 'side',
-    company: 'Side Project',
-    period: '2022',
+      'Developed a smart signage and analytics system for the University of Malaga campus. ' +
+      'Built a Firebase API to log and visualize pedestrian crossing statistics and interaction data. ' +
+      'Part of the larger Smart-Campus initiative focusing on urban mobility and data-driven infrastructure.',
+    companyId: 'uma',
+    company: 'Univ. Malaga',
+    period: 'Dec 2018 – Mar 2020',
     links: [
-      { label: '🚀 Live Demo', url: 'https://share.streamlit.io/matesanz/face-expression-recognition/main/app/main.py', type: 'primary' },
-      { label: '💻 Code', url: 'https://github.com/Matesanz/face-expression-recognition', type: 'outline' },
-    ],
-  },
-  {
-    id: 'pet-detector',
-    title: 'Pet Detector with YOLOv3',
-    emoji: '🐈',
-    description:
-      'Custom YOLOv3 object detection model trained from scratch to recognise a specific cat ' +
-      '(Mocka 😂). Used the ImageAI library inside a Jupyter Notebook, covering the full ' +
-      'pipeline: collecting hundreds of photos, annotating bounding boxes, training, and ' +
-      'validating with the mAP metric. Presented live at TabularConf 2021, my first national ' +
-      'conference.',
-    companyId: 'side',
-    company: 'Side Project',
-    period: '2021',
-    links: [
-      { label: '▶ Watch Talk', url: 'https://www.youtube.com/watch?v=Fr8t0SuHASA', type: 'primary' },
-      { label: '💻 Code', url: 'https://github.com/Matesanz/pet-detector', type: 'outline' },
+      { label: '💻 StreetQR', url: 'https://github.com/Matesanz/StreetQR', type: 'outline' },
     ],
   },
   {
@@ -285,7 +398,7 @@ export const projects: Project[] = [
       'continues to grow the local AI community.',
     companyId: 'side',
     company: 'Side Project',
-    period: '2018 – Present',
+    period: 'Sep 2018 – Dec 2023',
     links: [
       { label: '🐦 Twitter', url: 'https://twitter.com/aimalaga', type: 'outline' },
     ],

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -16,6 +16,21 @@ const { title, description } = Astro.props;
 <html lang="en">
   <head>
     <BaseHead title={title} description={description} />
+    <!-- Google tag (gtag.js) -->
+    <script is:inline define:vars={{ gaId: import.meta.env.PUBLIC_GA_ID }}>
+      const consent = localStorage.getItem('cookie-consent');
+      if (consent === 'accepted' && gaId) {
+        const script = document.createElement('script');
+        script.async = true;
+        script.src = `https://www.googletagmanager.com/gtag/js?id=${gaId}`;
+        document.head.appendChild(script);
+
+        window.dataLayer = window.dataLayer || [];
+        function gtag(){dataLayer.push(arguments);}
+        gtag('js', new Date());
+        gtag('config', gaId, { 'anonymize_ip': true });
+      }
+    </script>
   </head>
   <body class="min-h-screen flex flex-col">
     <Nav />
@@ -23,5 +38,47 @@ const { title, description } = Astro.props;
       <slot />
     </main>
     <Footer />
+
+    <!-- Cookie Consent Banner -->
+    <div id="cookie-banner" class="fixed bottom-0 left-0 right-0 bg-gray-900 text-white p-4 z-[100] transform translate-y-full transition-transform duration-300 print:hidden">
+      <div class="max-w-4xl mx-auto flex flex-col sm:flex-row items-center justify-between gap-4 text-center sm:text-left">
+        <p class="text-sm">
+          I use basic analytics to understand how this site is used. By clicking "Accept", you agree to the use of cookies for these purposes.
+        </p>
+        <div class="flex gap-4">
+          <button id="decline-cookies" class="text-sm text-gray-400 hover:text-white transition-colors">Decline</button>
+          <button id="accept-cookies" class="bg-indigo-600 hover:bg-indigo-700 text-white px-6 py-2 rounded-lg text-sm font-semibold transition-all">Accept</button>
+        </div>
+      </div>
+    </div>
+
+    <script is:inline>
+      const banner = document.getElementById('cookie-banner');
+      const acceptBtn = document.getElementById('accept-cookies');
+      const declineBtn = document.getElementById('decline-cookies');
+
+      function showBanner() {
+        banner.classList.remove('translate-y-full');
+      }
+
+      function hideBanner() {
+        banner.classList.add('translate-y-full');
+      }
+
+      function setConsent(consented) {
+        localStorage.setItem('cookie-consent', consented ? 'accepted' : 'declined');
+        hideBanner();
+        if (consented) {
+          window.location.reload(); // Reload to enable GA
+        }
+      }
+
+      if (!localStorage.getItem('cookie-consent')) {
+        setTimeout(showBanner, 1000);
+      }
+
+      acceptBtn?.addEventListener('click', () => setConsent(true));
+      declineBtn?.addEventListener('click', () => setConsent(false));
+    </script>
   </body>
 </html>

--- a/src/pages/cv.astro
+++ b/src/pages/cv.astro
@@ -270,7 +270,7 @@ import SkillBadges from '../components/SkillBadges.astro';
       <!-- TechFest 2024 -->
       <div class="card">
         <div class="flex flex-col sm:flex-row sm:items-start sm:justify-between gap-1 mb-2">
-          <h3 class="text-base font-semibold text-gray-900">¡Triple sobre la bocina! El apasionante mundo del Computer Vision 3D</h3>
+          <h3 class="text-base font-semibold text-gray-900">Buzzer Beater! The Fascinating World of 3D Computer Vision</h3>
           <span class="text-xs text-indigo-600 font-medium whitespace-nowrap">TechFest · Mar 2024</span>
         </div>
         <p class="text-sm text-gray-600 mb-3">
@@ -286,7 +286,7 @@ import SkillBadges from '../components/SkillBadges.astro';
       <!-- PyData Granada 2024 -->
       <div class="card">
         <div class="flex flex-col sm:flex-row sm:items-start sm:justify-between gap-1 mb-2">
-          <h3 class="text-base font-semibold text-gray-900">IA No Code: Creando un producto de IA en 30 minutos</h3>
+          <h3 class="text-base font-semibold text-gray-900">No-Code AI: Building an AI Product in 30 Minutes</h3>
           <span class="text-xs text-indigo-600 font-medium whitespace-nowrap">PyData Granada · Nov 2024</span>
         </div>
         <p class="text-sm text-gray-600 mb-3">

--- a/src/pages/cv.astro
+++ b/src/pages/cv.astro
@@ -1,6 +1,7 @@
 ---
 import BaseLayout from '../layouts/BaseLayout.astro';
 import SkillBadges from '../components/SkillBadges.astro';
+import { getProjectsByCompany } from '../data/projects';
 ---
 
 <BaseLayout
@@ -20,11 +21,11 @@ import SkillBadges from '../components/SkillBadges.astro';
       <p class="text-lg text-indigo-600 font-medium mb-3">AI Engineer · Computer Vision · Automation</p>
       <p class="text-gray-600 leading-relaxed text-sm max-w-2xl mb-5">
         AI Engineer with <strong>7+ years turning research into products that ship</strong>. I specialize in
-        bridging the gap between what AI can do and what organizations actually need — from cutting
-        <strong>course production time by 90%</strong> at Labster using n8n + Claude automations, to launching
-        a <strong>3D padel analytics startup</strong>, building <strong>cashierless retail AI</strong> for Mercadona,
-        and creating a real-time basketball tracker for an <strong>NBA champion's academy</strong>. I don't just
-        train models — I own the product journey from prototype to working demo.
+        bridging the gap between what AI can do and what organizations actually need. My track record includes
+        <strong>cutting production costs by 90%</strong> through intelligent automation at Labster, launching
+        <strong>computer vision startups</strong> from scratch, and building <strong>real-time AI solutions</strong>
+        for industry leaders like Mercadona and elite sports academies. I don't just train models — I own the
+        full product journey from initial prototype to production-ready demo.
       </p>
       <!-- Social links -->
       <div class="flex flex-wrap justify-center sm:justify-start gap-3">
@@ -50,9 +51,31 @@ import SkillBadges from '../components/SkillBadges.astro';
           </svg>
           GitHub
         </a>
+        <a
+          href="https://twitter.com/aimatesanz"
+          target="_blank"
+          rel="noopener noreferrer"
+          class="btn-outline print:hidden"
+        >
+          <svg class="w-4 h-4" fill="currentColor" viewBox="0 0 24 24">
+            <path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-5.214-6.817L4.99 21.75H1.68l7.73-8.835L1.254 2.25H8.08l4.713 6.231zm-1.161 17.52h1.833L7.084 4.126H5.117z" />
+          </svg>
+          X (Twitter)
+        </a>
+        <a
+          href="https://medium.com/@matesanz.cuadrado"
+          target="_blank"
+          rel="noopener noreferrer"
+          class="btn-outline print:hidden"
+        >
+          <svg class="w-4 h-4" fill="currentColor" viewBox="0 0 24 24">
+            <path d="M13.54 12a6.8 6.8 0 11-6.77-6.82A6.77 6.77 0 0113.54 12zm7.42 0c0 3.54-1.51 6.42-3.38 6.42S14.2 15.54 14.2 12s1.51-6.42 3.38-6.42 3.38 2.88 3.38 6.42zm3.04 0c0 3.25-.31 5.88-.7 5.88s-.7-2.63-.7-5.88.31-5.88.7-5.88.7 2.63.7 5.88z" />
+          </svg>
+          Medium
+        </a>
         <!-- Print-only contact line -->
         <span class="hidden print:inline text-sm text-gray-600">
-          linkedin.com/in/aimatesanz · github.com/Matesanz
+          linkedin.com/in/aimatesanz · github.com/Matesanz · x.com/aimatesanz
         </span>
       </div>
     </div>
@@ -75,12 +98,53 @@ import SkillBadges from '../components/SkillBadges.astro';
           </div>
           <span class="text-xs text-gray-500 whitespace-nowrap sm:text-right">Apr 2025 – Present</span>
         </div>
-        <p class="text-sm text-gray-700 leading-relaxed mt-2">
-          Reduced VR science course production time by <strong>90%</strong> by designing AI-powered internal workflows
-          using <strong>Airtable, n8n, Claude</strong> and <strong>OpenAI</strong>. Built tailored processes for Learning Experts
-          and Subject Matter Experts covering Bloom's taxonomy, learning objectives, and driving questions — making
-          high-quality VR simulations dramatically cheaper to produce.
+        <p class="text-sm text-gray-700 leading-relaxed mt-2 mb-4">
+          Designing and shipping <strong>AI-powered automation</strong> to radically accelerate
+          internal product workflows — cutting production costs by <strong>90%</strong> while
+          preserving quality at scale.
         </p>
+
+        <div class="grid grid-cols-1 sm:grid-cols-2 gap-2 mt-2 print:hidden">
+          {getProjectsByCompany('labster').map(project => (
+            <a 
+              href={`/projects#${project.id}`} 
+              class="flex items-center gap-2 p-2 rounded-md bg-gray-50 border border-gray-100 hover:border-indigo-200 hover:bg-indigo-50/30 transition-all group"
+            >
+              <span class="text-lg">{project.emoji}</span>
+              <span class="text-xs font-medium text-gray-700 group-hover:text-indigo-600">{project.title}</span>
+              <span class="ml-auto text-indigo-400 opacity-0 group-hover:opacity-100 transition-opacity">→</span>
+            </a>
+          ))}
+        </div>
+      </div>
+
+      <!-- Freelance -->
+      <div class="card">
+        <div class="flex flex-col sm:flex-row sm:items-start sm:justify-between gap-1 mb-1">
+          <div>
+            <h3 class="text-base font-semibold text-gray-900">Video Movement Prediction Model</h3>
+            <p class="text-sm font-medium text-indigo-600">Independent · Deep Learning</p>
+          </div>
+          <span class="text-xs text-gray-500 whitespace-nowrap sm:text-right">Mar – Jun 2025</span>
+        </div>
+        <p class="text-sm text-gray-700 leading-relaxed mt-2 mb-4">
+          Independent R&D — applied <strong>cutting-edge deep learning research</strong> to solve
+          a specific client problem, owning the full pipeline from architecture design to evaluation.
+          <span class="text-gray-400 italic">(NDA — further details confidential.)</span>
+        </p>
+
+        <div class="grid grid-cols-1 sm:grid-cols-2 gap-2 mt-2 print:hidden">
+          {getProjectsByCompany('freelance').map(project => (
+            <a 
+              href={`/projects#${project.id}`} 
+              class="flex items-center gap-2 p-2 rounded-md bg-gray-50 border border-gray-100 hover:border-indigo-200 hover:bg-indigo-50/30 transition-all group"
+            >
+              <span class="text-lg">{project.emoji}</span>
+              <span class="text-xs font-medium text-gray-700 group-hover:text-indigo-600">{project.title}</span>
+              <span class="ml-auto text-indigo-400 opacity-0 group-hover:opacity-100 transition-opacity">→</span>
+            </a>
+          ))}
+        </div>
       </div>
 
       <!-- Codespace Academy -->
@@ -90,12 +154,25 @@ import SkillBadges from '../components/SkillBadges.astro';
             <h3 class="text-base font-semibold text-gray-900">Bootcamp Instructor</h3>
             <p class="text-sm font-medium text-indigo-600">Codespace Academy</p>
           </div>
-          <span class="text-xs text-gray-500 whitespace-nowrap sm:text-right">May 2023 – Present</span>
+          <span class="text-xs text-gray-500 whitespace-nowrap sm:text-right">May 2023 – Dec 2023</span>
         </div>
-        <p class="text-sm text-gray-700 leading-relaxed mt-2">
-          Full curriculum design and delivery for Machine Learning bootcamp cohorts —
-          <strong>Python, deep learning, MLOps</strong>, experiment tracking, Docker, and model deployment.
+        <p class="text-sm text-gray-700 leading-relaxed mt-2 mb-4">
+          Full <strong>curriculum design and delivery</strong> for Machine Learning bootcamps —
+          taking students from fundamentals to production-ready skills across AI, MLOps, and software engineering.
         </p>
+
+        <div class="grid grid-cols-1 sm:grid-cols-2 gap-2 mt-2 print:hidden">
+          {getProjectsByCompany('codespace').map(project => (
+            <a 
+              href={`/projects#${project.id}`} 
+              class="flex items-center gap-2 p-2 rounded-md bg-gray-50 border border-gray-100 hover:border-indigo-200 hover:bg-indigo-50/30 transition-all group"
+            >
+              <span class="text-lg">{project.emoji}</span>
+              <span class="text-xs font-medium text-gray-700 group-hover:text-indigo-600">{project.title}</span>
+              <span class="ml-auto text-indigo-400 opacity-0 group-hover:opacity-100 transition-opacity">→</span>
+            </a>
+          ))}
+        </div>
       </div>
 
       <!-- SNGULAR -->
@@ -107,34 +184,24 @@ import SkillBadges from '../components/SkillBadges.astro';
           </div>
           <span class="text-xs text-gray-500 whitespace-nowrap sm:text-right">Mar 2022 – Apr 2025</span>
         </div>
-        <p class="text-sm text-gray-700 leading-relaxed mt-2 mb-3">
-          Delivered multiple high-impact AI products across retail, sports, real estate, and banking:
+        <p class="text-sm text-gray-700 leading-relaxed mt-2 mb-4">
+          Launched <strong>AI products from zero to demo</strong> across multiple industries.
+          Owned the full lifecycle — research, prototyping, model development, and delivery —
+          consistently shipping under tight deadlines and ambiguous requirements.
         </p>
-        <ul class="space-y-2 text-sm text-gray-600">
-          <li class="flex items-start gap-2">
-            <span class="text-indigo-400 mt-0.5 flex-shrink-0">▸</span>
-            <span><strong>Banco Santander</strong> (Dec 2024–Mar 2025) — Designed an MVP for safe internal AI adoption at a major financial institution; studied how leading global companies govern AI.</span>
-          </li>
-          <li class="flex items-start gap-2">
-            <span class="text-indigo-400 mt-0.5 flex-shrink-0">▸</span>
-            <span><strong>Real Estate AI</strong> (2024) — Built an end-to-end pipeline ingesting legal and technical property documents into a structured database, replacing manual expert review.</span>
-          </li>
-          <li class="flex items-start gap-2">
-            <span class="text-indigo-400 mt-0.5 flex-shrink-0">▸</span>
-            <span><strong>The Embassy / KM Calderón</strong> (Summer 2023) — Real-time AI basketball match evaluation tool for the academy of KM Calderón, Spanish NBA champion.</span>
-          </li>
-          <li class="flex items-start gap-2">
-            <span class="text-indigo-400 mt-0.5 flex-shrink-0">▸</span>
-            <span>
-              <strong>PADMI Startup</strong> (Jan–Jul 2023) — Built the initial AI from scratch in 6 months; launched a working 3D CV padel performance prototype at{' '}
-              <a href="https://www.padmi.es/" target="_blank" rel="noopener noreferrer" class="text-indigo-600 hover:underline print:no-underline">padmi.es</a>.
-            </span>
-          </li>
-          <li class="flex items-start gap-2">
-            <span class="text-indigo-400 mt-0.5 flex-shrink-0">▸</span>
-            <span><strong>Mercadona Tech</strong> (Mar–Dec 2022) — Cashierless store MVP using 3D Computer Vision and AI for Spain's largest supermarket chain.</span>
-          </li>
-        </ul>
+        
+        <div class="grid grid-cols-1 sm:grid-cols-2 gap-2 mt-2 print:hidden">
+          {getProjectsByCompany('sngular').map(project => (
+            <a 
+              href={`/projects#${project.id}`} 
+              class="flex items-center gap-2 p-2 rounded-md bg-gray-50 border border-gray-100 hover:border-indigo-200 hover:bg-indigo-50/30 transition-all group"
+            >
+              <span class="text-lg">{project.emoji}</span>
+              <span class="text-xs font-medium text-gray-700 group-hover:text-indigo-600">{project.title}</span>
+              <span class="ml-auto text-indigo-400 opacity-0 group-hover:opacity-100 transition-opacity">→</span>
+            </a>
+          ))}
+        </div>
       </div>
 
       <!-- Aeorum -->
@@ -146,11 +213,24 @@ import SkillBadges from '../components/SkillBadges.astro';
           </div>
           <span class="text-xs text-gray-500 whitespace-nowrap sm:text-right">Sept 2020 – Mar 2022</span>
         </div>
-        <p class="text-sm text-gray-700 leading-relaxed mt-2">
-          Drone-based computer vision for agriculture and renewable energy using <strong>ROS + Python</strong>.
-          YOLO/SSD-MobileNet models for aerial recognition; thermal anomaly detection on solar panels;
-          multispectral orthomosaics for crop health; proprietary GeoTIFF generation from multi-camera arrays.
+        <p class="text-sm text-gray-700 leading-relaxed mt-2 mb-4">
+          Built and deployed <strong>computer vision systems on embedded hardware</strong> for
+          real-world field operations — bridging R&D with production-grade solutions in
+          challenging environments.
         </p>
+
+        <div class="grid grid-cols-1 sm:grid-cols-2 gap-2 mt-2 print:hidden">
+          {getProjectsByCompany('aeorum').map(project => (
+            <a 
+              href={`/projects#${project.id}`} 
+              class="flex items-center gap-2 p-2 rounded-md bg-gray-50 border border-gray-100 hover:border-indigo-200 hover:bg-indigo-50/30 transition-all group"
+            >
+              <span class="text-lg">{project.emoji}</span>
+              <span class="text-xs font-medium text-gray-700 group-hover:text-indigo-600">{project.title}</span>
+              <span class="ml-auto text-indigo-400 opacity-0 group-hover:opacity-100 transition-opacity">→</span>
+            </a>
+          ))}
+        </div>
       </div>
 
       <!-- University of Malaga -->
@@ -162,11 +242,24 @@ import SkillBadges from '../components/SkillBadges.astro';
           </div>
           <span class="text-xs text-gray-500 whitespace-nowrap sm:text-right">Dec 2018 – Mar 2020</span>
         </div>
-        <p class="text-sm text-gray-700 leading-relaxed mt-2">
-          Embedded object detection (YOLO, MobileNet, Mask-RCNN on Jetson Nano) in traffic signs to prevent
-          car-pedestrian collisions. Research published at{' '}
-          <a href="https://riuma.uma.es/xmlui/bitstream/handle/10630/18443/CIPI_2019_paper_37.pdf" target="_blank" rel="noopener noreferrer" class="text-indigo-600 hover:underline">CIPI 2019</a>.
+        <p class="text-sm text-gray-700 leading-relaxed mt-2 mb-4">
+          Applied <strong>research to real-world impact</strong> — designed and built AI prototypes
+          that went from academic concept to working field deployment, with results{' '}
+          <a href="https://riuma.uma.es/xmlui/bitstream/handle/10630/18443/CIPI_2019_paper_37.pdf" target="_blank" rel="noopener noreferrer" class="text-indigo-600 hover:underline">published at an international conference</a>.
         </p>
+
+        <div class="grid grid-cols-1 sm:grid-cols-2 gap-2 mt-2 print:hidden">
+          {getProjectsByCompany('uma').map(project => (
+            <a 
+              href={`/projects#${project.id}`} 
+              class="flex items-center gap-2 p-2 rounded-md bg-gray-50 border border-gray-100 hover:border-indigo-200 hover:bg-indigo-50/30 transition-all group"
+            >
+              <span class="text-lg">{project.emoji}</span>
+              <span class="text-xs font-medium text-gray-700 group-hover:text-indigo-600">{project.title}</span>
+              <span class="ml-auto text-indigo-400 opacity-0 group-hover:opacity-100 transition-opacity">→</span>
+            </a>
+          ))}
+        </div>
       </div>
 
       <!-- Monkeat -->
@@ -178,31 +271,26 @@ import SkillBadges from '../components/SkillBadges.astro';
           </div>
           <span class="text-xs text-gray-500 whitespace-nowrap sm:text-right">Mar 2019 – Oct 2019</span>
         </div>
-        <p class="text-sm text-gray-700 leading-relaxed mt-2">
-          Co-founded a live marketplace startup and acted as CTO — built the full PWA (Vue + Ionic, MongoDB, Flask, Firebase).
-          Entrepreneurial experience: from idea to MVP inside a Demium incubation program.
+        <p class="text-sm text-gray-700 leading-relaxed mt-2 mb-4">
+          Co-founded a startup and <strong>shipped the product end-to-end as CTO</strong> —
+          from architecture and development to launch. A formative experience in product
+          ownership, speed of execution, and knowing when to pivot.
         </p>
-      </div>
 
-    </div>
-  </section>
-
-  <!-- ── FREELANCE ──────────────────────────────────────────────────────── -->
-  <section class="mb-12">
-    <h2 class="section-title mb-8">🧑‍💻 Freelance</h2>
-    <div class="card">
-      <div class="flex flex-col sm:flex-row sm:items-start sm:justify-between gap-1 mb-1">
-        <div>
-          <h3 class="text-base font-semibold text-gray-900">Video Movement Prediction Model</h3>
-          <p class="text-sm font-medium text-indigo-600">Independent · Deep Learning</p>
+        <div class="grid grid-cols-1 sm:grid-cols-2 gap-2 mt-2 print:hidden">
+          {getProjectsByCompany('monkeat').map(project => (
+            <a 
+              href={`/projects#${project.id}`} 
+              class="flex items-center gap-2 p-2 rounded-md bg-gray-50 border border-gray-100 hover:border-indigo-200 hover:bg-indigo-50/30 transition-all group"
+            >
+              <span class="text-lg">{project.emoji}</span>
+              <span class="text-xs font-medium text-gray-700 group-hover:text-indigo-600">{project.title}</span>
+              <span class="ml-auto text-indigo-400 opacity-0 group-hover:opacity-100 transition-opacity">→</span>
+            </a>
+          ))}
         </div>
-        <span class="text-xs text-gray-500 whitespace-nowrap sm:text-right">Mar – Jun 2025</span>
       </div>
-      <p class="text-sm text-gray-700 leading-relaxed mt-2">
-        Designed and trained a <strong>PyTorch-based deep learning model</strong> for video movement prediction —
-        from architecture design and dataset preparation through to training and evaluation.
-        <span class="text-gray-400 italic">(NDA — further details confidential.)</span>
-      </p>
+
     </div>
   </section>
 

--- a/src/pages/cv.astro
+++ b/src/pages/cv.astro
@@ -1,0 +1,343 @@
+---
+import BaseLayout from '../layouts/BaseLayout.astro';
+import SkillBadges from '../components/SkillBadges.astro';
+---
+
+<BaseLayout
+  title="CV — Andrés Matesanz"
+  description="Recruiter-friendly CV of Andrés Matesanz: AI Engineer specializing in Computer Vision, automation and product delivery."
+>
+
+  <!-- ── HEADER ─────────────────────────────────────────────────────────── -->
+  <section class="py-10 flex flex-col sm:flex-row items-center sm:items-start gap-8 print:py-4">
+    <img
+      src="/profile.jpg"
+      alt="Andrés Matesanz"
+      class="w-28 h-28 rounded-full shadow-lg ring-4 ring-indigo-100 flex-shrink-0"
+    />
+    <div class="text-center sm:text-left">
+      <h1 class="text-3xl font-bold text-gray-900 mb-1">Andrés Matesanz</h1>
+      <p class="text-lg text-indigo-600 font-medium mb-3">AI Engineer · Computer Vision · Automation</p>
+      <p class="text-gray-600 leading-relaxed text-sm max-w-2xl mb-5">
+        AI Engineer with <strong>7+ years turning research into products that ship</strong>. I specialize in
+        bridging the gap between what AI can do and what organizations actually need — from cutting
+        <strong>course production time by 90%</strong> at Labster using n8n + Claude automations, to launching
+        a <strong>3D padel analytics startup</strong>, building <strong>cashierless retail AI</strong> for Mercadona,
+        and creating a real-time basketball tracker for an <strong>NBA champion's academy</strong>. I don't just
+        train models — I own the product journey from prototype to working demo.
+      </p>
+      <!-- Social links -->
+      <div class="flex flex-wrap justify-center sm:justify-start gap-3">
+        <a
+          href="https://www.linkedin.com/in/aimatesanz/"
+          target="_blank"
+          rel="noopener noreferrer"
+          class="btn-primary print:hidden"
+        >
+          <svg class="w-4 h-4" fill="currentColor" viewBox="0 0 24 24">
+            <path d="M20.447 20.452h-3.554v-5.569c0-1.328-.027-3.037-1.852-3.037-1.853 0-2.136 1.445-2.136 2.939v5.667H9.351V9h3.414v1.561h.046c.477-.9 1.637-1.85 3.37-1.85 3.601 0 4.267 2.37 4.267 5.455v6.286zM5.337 7.433a2.062 2.062 0 01-2.063-2.065 2.064 2.064 0 112.063 2.065zm1.782 13.019H3.555V9h3.564v11.452zM22.225 0H1.771C.792 0 0 .774 0 1.729v20.542C0 23.227.792 24 1.771 24h20.451C23.2 24 24 23.227 24 22.271V1.729C24 .774 23.2 0 22.222 0h.003z" />
+          </svg>
+          LinkedIn
+        </a>
+        <a
+          href="https://github.com/Matesanz"
+          target="_blank"
+          rel="noopener noreferrer"
+          class="btn-outline print:hidden"
+        >
+          <svg class="w-4 h-4" fill="currentColor" viewBox="0 0 24 24">
+            <path d="M12 2C6.477 2 2 6.484 2 12.017c0 4.425 2.865 8.18 6.839 9.504.5.092.682-.217.682-.483 0-.237-.008-.868-.013-1.703-2.782.605-3.369-1.343-3.369-1.343-.454-1.158-1.11-1.466-1.11-1.466-.908-.62.069-.608.069-.608 1.003.07 1.531 1.032 1.531 1.032.892 1.53 2.341 1.088 2.91.832.092-.647.35-1.088.636-1.338-2.22-.253-4.555-1.113-4.555-4.951 0-1.093.39-1.988 1.029-2.688-.103-.253-.446-1.272.098-2.65 0 0 .84-.27 2.75 1.026A9.564 9.564 0 0112 6.844c.85.004 1.705.115 2.504.337 1.909-1.296 2.747-1.027 2.747-1.027.546 1.379.202 2.398.1 2.651.64.7 1.028 1.595 1.028 2.688 0 3.848-2.339 4.695-4.566 4.943.359.309.678.92.678 1.855 0 1.338-.012 2.419-.012 2.747 0 .268.18.58.688.482A10.019 10.019 0 0022 12.017C22 6.484 17.522 2 12 2z" />
+          </svg>
+          GitHub
+        </a>
+        <!-- Print-only contact line -->
+        <span class="hidden print:inline text-sm text-gray-600">
+          linkedin.com/in/aimatesanz · github.com/Matesanz
+        </span>
+      </div>
+    </div>
+  </section>
+
+  <hr class="border-gray-200 mb-10" />
+
+  <!-- ── PROFESSIONAL EXPERIENCE ──────────────────────────────────────── -->
+  <section class="mb-12">
+    <h2 class="section-title mb-8">🧑‍💻 Professional Experience</h2>
+
+    <div class="space-y-6">
+
+      <!-- Labster -->
+      <div class="card">
+        <div class="flex flex-col sm:flex-row sm:items-start sm:justify-between gap-1 mb-1">
+          <div>
+            <h3 class="text-base font-semibold text-gray-900">AI Engineer</h3>
+            <p class="text-sm font-medium text-indigo-600">Labster</p>
+          </div>
+          <span class="text-xs text-gray-500 whitespace-nowrap sm:text-right">Apr 2025 – Present</span>
+        </div>
+        <p class="text-sm text-gray-700 leading-relaxed mt-2">
+          Reduced VR science course production time by <strong>90%</strong> by designing AI-powered internal workflows
+          using <strong>Airtable, n8n, Claude</strong> and <strong>OpenAI</strong>. Built tailored processes for Learning Experts
+          and Subject Matter Experts covering Bloom's taxonomy, learning objectives, and driving questions — making
+          high-quality VR simulations dramatically cheaper to produce.
+        </p>
+      </div>
+
+      <!-- Codespace Academy -->
+      <div class="card">
+        <div class="flex flex-col sm:flex-row sm:items-start sm:justify-between gap-1 mb-1">
+          <div>
+            <h3 class="text-base font-semibold text-gray-900">Bootcamp Instructor</h3>
+            <p class="text-sm font-medium text-indigo-600">Codespace Academy</p>
+          </div>
+          <span class="text-xs text-gray-500 whitespace-nowrap sm:text-right">May 2023 – Present</span>
+        </div>
+        <p class="text-sm text-gray-700 leading-relaxed mt-2">
+          Full curriculum design and delivery for Machine Learning bootcamp cohorts —
+          <strong>Python, deep learning, MLOps</strong>, experiment tracking, Docker, and model deployment.
+        </p>
+      </div>
+
+      <!-- SNGULAR -->
+      <div class="card">
+        <div class="flex flex-col sm:flex-row sm:items-start sm:justify-between gap-1 mb-1">
+          <div>
+            <h3 class="text-base font-semibold text-gray-900">Artificial Intelligence Engineer</h3>
+            <p class="text-sm font-medium text-indigo-600">SNGULAR</p>
+          </div>
+          <span class="text-xs text-gray-500 whitespace-nowrap sm:text-right">Mar 2022 – Apr 2025</span>
+        </div>
+        <p class="text-sm text-gray-700 leading-relaxed mt-2 mb-3">
+          Delivered multiple high-impact AI products across retail, sports, real estate, and banking:
+        </p>
+        <ul class="space-y-2 text-sm text-gray-600">
+          <li class="flex items-start gap-2">
+            <span class="text-indigo-400 mt-0.5 flex-shrink-0">▸</span>
+            <span><strong>Banco Santander</strong> (Dec 2024–Mar 2025) — Designed an MVP for safe internal AI adoption at a major financial institution; studied how leading global companies govern AI.</span>
+          </li>
+          <li class="flex items-start gap-2">
+            <span class="text-indigo-400 mt-0.5 flex-shrink-0">▸</span>
+            <span><strong>Real Estate AI</strong> (2024) — Built an end-to-end pipeline ingesting legal and technical property documents into a structured database, replacing manual expert review.</span>
+          </li>
+          <li class="flex items-start gap-2">
+            <span class="text-indigo-400 mt-0.5 flex-shrink-0">▸</span>
+            <span><strong>The Embassy / KM Calderón</strong> (Summer 2023) — Real-time AI basketball match evaluation tool for the academy of KM Calderón, Spanish NBA champion.</span>
+          </li>
+          <li class="flex items-start gap-2">
+            <span class="text-indigo-400 mt-0.5 flex-shrink-0">▸</span>
+            <span>
+              <strong>PADMI Startup</strong> (Jan–Jul 2023) — Built the initial AI from scratch in 6 months; launched a working 3D CV padel performance prototype at{' '}
+              <a href="https://www.padmi.es/" target="_blank" rel="noopener noreferrer" class="text-indigo-600 hover:underline print:no-underline">padmi.es</a>.
+            </span>
+          </li>
+          <li class="flex items-start gap-2">
+            <span class="text-indigo-400 mt-0.5 flex-shrink-0">▸</span>
+            <span><strong>Mercadona Tech</strong> (Mar–Dec 2022) — Cashierless store MVP using 3D Computer Vision and AI for Spain's largest supermarket chain.</span>
+          </li>
+        </ul>
+      </div>
+
+      <!-- Aeorum -->
+      <div class="card">
+        <div class="flex flex-col sm:flex-row sm:items-start sm:justify-between gap-1 mb-1">
+          <div>
+            <h3 class="text-base font-semibold text-gray-900">Computer Vision Developer</h3>
+            <p class="text-sm font-medium text-indigo-600">Aeorum</p>
+          </div>
+          <span class="text-xs text-gray-500 whitespace-nowrap sm:text-right">Sept 2020 – Mar 2022</span>
+        </div>
+        <p class="text-sm text-gray-700 leading-relaxed mt-2">
+          Drone-based computer vision for agriculture and renewable energy using <strong>ROS + Python</strong>.
+          YOLO/SSD-MobileNet models for aerial recognition; thermal anomaly detection on solar panels;
+          multispectral orthomosaics for crop health; proprietary GeoTIFF generation from multi-camera arrays.
+        </p>
+      </div>
+
+      <!-- University of Malaga -->
+      <div class="card">
+        <div class="flex flex-col sm:flex-row sm:items-start sm:justify-between gap-1 mb-1">
+          <div>
+            <h3 class="text-base font-semibold text-gray-900">R&D Developer — AI & Computer Vision</h3>
+            <p class="text-sm font-medium text-indigo-600">University of Malaga — Smart-Campus Projects</p>
+          </div>
+          <span class="text-xs text-gray-500 whitespace-nowrap sm:text-right">Dec 2018 – Mar 2020</span>
+        </div>
+        <p class="text-sm text-gray-700 leading-relaxed mt-2">
+          Embedded object detection (YOLO, MobileNet, Mask-RCNN on Jetson Nano) in traffic signs to prevent
+          car-pedestrian collisions. Research published at{' '}
+          <a href="https://riuma.uma.es/xmlui/bitstream/handle/10630/18443/CIPI_2019_paper_37.pdf" target="_blank" rel="noopener noreferrer" class="text-indigo-600 hover:underline">CIPI 2019</a>.
+        </p>
+      </div>
+
+      <!-- Monkeat -->
+      <div class="card">
+        <div class="flex flex-col sm:flex-row sm:items-start sm:justify-between gap-1 mb-1">
+          <div>
+            <h3 class="text-base font-semibold text-gray-900">Full-Stack Developer & CTO</h3>
+            <p class="text-sm font-medium text-indigo-600">Monkeat — Startup (Demium Incubation Program)</p>
+          </div>
+          <span class="text-xs text-gray-500 whitespace-nowrap sm:text-right">Mar 2019 – Oct 2019</span>
+        </div>
+        <p class="text-sm text-gray-700 leading-relaxed mt-2">
+          Co-founded a live marketplace startup and acted as CTO — built the full PWA (Vue + Ionic, MongoDB, Flask, Firebase).
+          Entrepreneurial experience: from idea to MVP inside a Demium incubation program.
+        </p>
+      </div>
+
+    </div>
+  </section>
+
+  <!-- ── FREELANCE ──────────────────────────────────────────────────────── -->
+  <section class="mb-12">
+    <h2 class="section-title mb-8">🧑‍💻 Freelance</h2>
+    <div class="card">
+      <div class="flex flex-col sm:flex-row sm:items-start sm:justify-between gap-1 mb-1">
+        <div>
+          <h3 class="text-base font-semibold text-gray-900">Video Movement Prediction Model</h3>
+          <p class="text-sm font-medium text-indigo-600">Independent · Deep Learning</p>
+        </div>
+        <span class="text-xs text-gray-500 whitespace-nowrap sm:text-right">Mar – Jun 2025</span>
+      </div>
+      <p class="text-sm text-gray-700 leading-relaxed mt-2">
+        Designed and trained a <strong>PyTorch-based deep learning model</strong> for video movement prediction —
+        from architecture design and dataset preparation through to training and evaluation.
+        <span class="text-gray-400 italic">(NDA — further details confidential.)</span>
+      </p>
+    </div>
+  </section>
+
+  <!-- ── EDUCATION ──────────────────────────────────────────────────────── -->
+  <section class="mb-12">
+    <h2 class="section-title mb-8">🎓 Education</h2>
+    <div class="space-y-4">
+
+      <div class="card">
+        <div class="flex flex-col sm:flex-row sm:items-start sm:justify-between gap-1 mb-1">
+          <div>
+            <h3 class="text-base font-semibold text-gray-900">Master's in Artificial Intelligence and Software Engineering</h3>
+            <p class="text-sm font-medium text-indigo-600">University of Malaga — Mention in Research</p>
+          </div>
+          <span class="text-xs text-gray-500 whitespace-nowrap sm:text-right">Sept 2019 – Jun 2020</span>
+        </div>
+        <p class="text-sm text-gray-700 mt-2">
+          Reinforcement Learning, Generative Models, Big Data, Evolutive Algorithms.{' '}
+          <strong>Graduated with Honors</strong> — Thesis:{' '}
+          <a href="https://1drv.ms/b/s!AgDuqWQZkjwxj79zyt5colGiRdNT1g?e=1cslcH" target="_blank" rel="noopener noreferrer" class="text-indigo-600 hover:underline">
+            3D MRI Super-Resolution using GANs
+          </a>{' '}
+          (4× image quality improvement).
+        </p>
+      </div>
+
+      <div class="card">
+        <div class="flex flex-col sm:flex-row sm:items-start sm:justify-between gap-1 mb-1">
+          <div>
+            <h3 class="text-base font-semibold text-gray-900">Master's in VR, AR and Videogame Development</h3>
+            <p class="text-sm font-medium text-indigo-600">VR EVO School</p>
+          </div>
+          <span class="text-xs text-gray-500 whitespace-nowrap sm:text-right">Sept 2017 – Jun 2018</span>
+        </div>
+        <p class="text-sm text-gray-700 mt-2">
+          Virtual Reality, Augmented Reality, game theory and procedural generation using Unreal Engine 4.
+        </p>
+      </div>
+
+      <div class="card">
+        <div class="flex flex-col sm:flex-row sm:items-start sm:justify-between gap-1 mb-1">
+          <div>
+            <h3 class="text-base font-semibold text-gray-900">Bachelor's Degree in Optics</h3>
+            <p class="text-sm font-medium text-indigo-600">University of Valladolid & Bicocca University (Erasmus)</p>
+          </div>
+          <span class="text-xs text-gray-500 whitespace-nowrap sm:text-right">Sept 2011 – Jun 2015</span>
+        </div>
+        <p class="text-sm text-gray-700 mt-2">
+          Physics, mathematics, neurology and biology of vision. Erasmus exchange at Bicocca University (2013–2014).
+          2nd place at Cooper FORCE Competition 2015.
+        </p>
+      </div>
+
+    </div>
+  </section>
+
+  <!-- ── SKILLS ─────────────────────────────────────────────────────────── -->
+  <SkillBadges />
+
+  <!-- ── SELECTED TALKS ─────────────────────────────────────────────────── -->
+  <section class="mb-12">
+    <h2 class="section-title mb-8">🗣️ Selected Talks</h2>
+    <div class="space-y-4">
+
+      <!-- TechFest 2024 -->
+      <div class="card">
+        <div class="flex flex-col sm:flex-row sm:items-start sm:justify-between gap-1 mb-2">
+          <h3 class="text-base font-semibold text-gray-900">¡Triple sobre la bocina! El apasionante mundo del Computer Vision 3D</h3>
+          <span class="text-xs text-indigo-600 font-medium whitespace-nowrap">TechFest · Mar 2024</span>
+        </div>
+        <p class="text-sm text-gray-600 mb-3">
+          Live-tracked a real basketball in 3D at one of Spain's most prominent tech festivals using locally-running
+          computer vision models and Rerun for real-time visualisation. All on-device, zero cloud.
+        </p>
+        <a href="https://www.youtube.com/watch?v=v_vFJkKw9kU&t=1118s" target="_blank" rel="noopener noreferrer" class="btn-primary text-xs px-3 py-1.5 print:hidden">
+          ▶ Watch on YouTube
+        </a>
+        <span class="hidden print:inline text-xs text-gray-500">youtube.com/watch?v=v_vFJkKw9kU</span>
+      </div>
+
+      <!-- PyData Granada 2024 -->
+      <div class="card">
+        <div class="flex flex-col sm:flex-row sm:items-start sm:justify-between gap-1 mb-2">
+          <h3 class="text-base font-semibold text-gray-900">IA No Code: Creando un producto de IA en 30 minutos</h3>
+          <span class="text-xs text-indigo-600 font-medium whitespace-nowrap">PyData Granada · Nov 2024</span>
+        </div>
+        <p class="text-sm text-gray-600 mb-3">
+          Live-built a fully functional generative AI avatar bot (Telegram + Make.com + HuggingFace Spaces)
+          in 30 minutes with zero code written, at the II Congreso de IA de Andalucía.
+        </p>
+        <a href="https://www.meetup.com/es-ES/pydatagrx/events/304163686/" target="_blank" rel="noopener noreferrer" class="btn-outline text-xs px-3 py-1.5 print:hidden">
+          📅 Event Page
+        </a>
+      </div>
+
+      <!-- TabularConf 2021 -->
+      <div class="card">
+        <div class="flex flex-col sm:flex-row sm:items-start sm:justify-between gap-1 mb-2">
+          <h3 class="text-base font-semibold text-gray-900">Detecting your Pet using AI</h3>
+          <span class="text-xs text-indigo-600 font-medium whitespace-nowrap">TabularConf · Jan 2021</span>
+        </div>
+        <p class="text-sm text-gray-600 mb-3">
+          Custom YOLOv3 model trained from scratch to detect a specific cat — shown live at my first national
+          congress. Covered end-to-end object detection: data collection, training, and mAP validation.
+        </p>
+        <a href="https://www.youtube.com/watch?v=Fr8t0SuHASA" target="_blank" rel="noopener noreferrer" class="btn-primary text-xs px-3 py-1.5 print:hidden">
+          ▶ Watch on YouTube
+        </a>
+        <span class="hidden print:inline text-xs text-gray-500">youtube.com/watch?v=Fr8t0SuHASA</span>
+      </div>
+
+    </div>
+    <p class="text-sm text-gray-400 mt-4 italic">
+      See all 11 talks on the <a href="/talks" class="text-indigo-500 hover:underline print:hidden">Talks page</a><span class="hidden print:inline">talks page at matesanz.github.io/talks</span>.
+    </p>
+  </section>
+
+  <!-- ── CTA ────────────────────────────────────────────────────────────── -->
+  <section class="py-8 text-center print:hidden">
+    <div class="card bg-indigo-50 border-indigo-200">
+      <p class="text-gray-700 mb-4 text-sm">
+        Want the full picture? My LinkedIn profile has the complete history, recommendations, and more detail on each project.
+      </p>
+      <a
+        href="https://www.linkedin.com/in/aimatesanz/"
+        target="_blank"
+        rel="noopener noreferrer"
+        class="btn-primary"
+      >
+        <svg class="w-4 h-4" fill="currentColor" viewBox="0 0 24 24">
+          <path d="M20.447 20.452h-3.554v-5.569c0-1.328-.027-3.037-1.852-3.037-1.853 0-2.136 1.445-2.136 2.939v5.667H9.351V9h3.414v1.561h.046c.477-.9 1.637-1.85 3.37-1.85 3.601 0 4.267 2.37 4.267 5.455v6.286zM5.337 7.433a2.062 2.062 0 01-2.063-2.065 2.064 2.064 0 112.063 2.065zm1.782 13.019H3.555V9h3.564v11.452zM22.225 0H1.771C.792 0 0 .774 0 1.729v20.542C0 23.227.792 24 1.771 24h20.451C23.2 24 24 23.227 24 22.271V1.729C24 .774 23.2 0 22.222 0h.003z" />
+        </svg>
+        View full profile on LinkedIn
+      </a>
+    </div>
+  </section>
+
+</BaseLayout>

--- a/src/pages/experience.astro
+++ b/src/pages/experience.astro
@@ -23,12 +23,13 @@ const freelanceProjects = getProjectsByCompany('freelance');
 
   <!-- Jump links -->
   <div class="flex flex-wrap gap-2 mb-10">
-    <a href="#labster"   class="btn-outline text-xs px-3 py-1.5">🧪 Labster</a>
-    <a href="#codespace" class="btn-outline text-xs px-3 py-1.5">🎓 Codespace Academy</a>
-    <a href="#sngular"   class="btn-outline text-xs px-3 py-1.5">🤖 SNGULAR</a>
-    <a href="#aeorum"    class="btn-outline text-xs px-3 py-1.5">🚁 Aeorum</a>
-    <a href="#uma"       class="btn-outline text-xs px-3 py-1.5">🧑‍🔬 Univ. Malaga</a>
-    <a href="#monkeat"   class="btn-outline text-xs px-3 py-1.5">🕵️ Monkeat</a>
+    <a href="#labster"   class="btn-outline text-xs px-3 py-1.5">📅 2026</a>
+    <a href="#freelance" class="btn-outline text-xs px-3 py-1.5">📅 2025</a>
+    <a href="#codespace" class="btn-outline text-xs px-3 py-1.5">📅 2023</a>
+    <a href="#sngular"   class="btn-outline text-xs px-3 py-1.5">📅 2022</a>
+    <a href="#aeorum"    class="btn-outline text-xs px-3 py-1.5">📅 2020-22</a>
+    <a href="#monkeat"   class="btn-outline text-xs px-3 py-1.5">📅 2019</a>
+    <a href="#uma"       class="btn-outline text-xs px-3 py-1.5">📅 2018</a>
   </div>
 
   <div class="relative">
@@ -38,13 +39,12 @@ const freelanceProjects = getProjectsByCompany('freelance');
       <TimelineEntry
         title="AI Engineer"
         subtitle="Labster"
+        subtitleUrl="https://www.labster.com/"
         period="Apr 2025 – Present"
       >
         <p class="text-sm text-gray-700 leading-relaxed mb-5">
-          At Labster, our product is <strong>VR/3D interactive science simulations</strong> for
-          universities and high schools — immersive and high-quality, but expensive to produce.
-          My mission is to change that ratio without touching the quality, using AI automation
-          and low-code tooling.
+          Designing and shipping <strong>AI-powered automation</strong> to radically accelerate
+          internal product workflows — cutting production costs while preserving quality at scale.
         </p>
         {labsterProjects.length > 0 && (
           <div>
@@ -67,17 +67,49 @@ const freelanceProjects = getProjectsByCompany('freelance');
       </TimelineEntry>
     </div>
 
+    <!-- Freelance -->
+    <div id="freelance">
+      <TimelineEntry
+        title="Freelance AI & Deep Learning"
+        subtitle="Independent"
+        period="Mar – Jun 2025"
+      >
+        <p class="text-sm text-gray-700 leading-relaxed mb-5">
+          Independent R&D and consulting — applying <strong>cutting-edge AI research</strong> to
+          solve specific client problems on a project basis.
+        </p>
+        {freelanceProjects.length > 0 && (
+          <div>
+            <h4 class="text-xs font-semibold text-gray-400 uppercase tracking-wider mb-3">Projects</h4>
+            <div class="space-y-2">
+              {freelanceProjects.map(p => (
+                <a href={`/projects#${p.id}`} class="flex items-start justify-between gap-3 p-3 rounded-lg border border-gray-100 hover:border-indigo-200 hover:bg-indigo-50/40 transition-colors group">
+                  <div class="min-w-0">
+                    <p class="text-sm font-medium text-gray-800 group-hover:text-indigo-700 transition-colors">
+                      {p.emoji} {p.title}
+                    </p>
+                    <p class="text-xs text-gray-500 mt-0.5 line-clamp-1">{p.description.slice(0, 100)}…</p>
+                  </div>
+                  <span class="text-xs text-indigo-500 whitespace-nowrap mt-0.5 flex-shrink-0">View →</span>
+                </a>
+              ))}
+            </div>
+          </div>
+        )}
+      </TimelineEntry>
+    </div>
+
     <!-- Codespace Academy -->
     <div id="codespace">
       <TimelineEntry
         title="Bootcamp Instructor"
         subtitle="Codespace Academy"
-        period="May 2023 – Present"
+        subtitleUrl="https://codespaceacademy.com/"
+        period="May 2023 – Dec 2023"
       >
         <p class="text-sm text-gray-700 leading-relaxed mb-5">
-          Teaching the next generation of ML engineers everything I know about
-          <strong>Machine Learning</strong>, <strong>Python</strong> and <strong>MLOps</strong>.
-          Full curriculum design and delivery for bootcamp cohorts.
+          Full <strong>curriculum design and delivery</strong> for Machine Learning bootcamps —
+          taking students from fundamentals to production-ready skills across AI, MLOps, and software engineering.
         </p>
         {codespaceProjects.length > 0 && (
           <div>
@@ -105,12 +137,13 @@ const freelanceProjects = getProjectsByCompany('freelance');
       <TimelineEntry
         title="Artificial Intelligence Engineer"
         subtitle="SNGULAR"
+        subtitleUrl="https://www.sngular.com/"
         period="Mar 2022 – Apr 2025"
       >
         <p class="text-sm text-gray-700 leading-relaxed mb-5">
-          Worked across multiple high-impact AI products in different industries — from retail
-          and sports to real estate and banking. Each project had a clear product goal and a
-          tight delivery timeline.
+          Launched <strong>AI products from zero to demo</strong> across multiple industries.
+          Owned the full lifecycle — research, prototyping, model development, and delivery —
+          consistently shipping under tight deadlines and ambiguous requirements.
         </p>
         {sngularProjects.length > 0 && (
           <div>
@@ -138,50 +171,19 @@ const freelanceProjects = getProjectsByCompany('freelance');
       <TimelineEntry
         title="Computer Vision Developer"
         subtitle="Aeorum"
+        subtitleUrl="https://aeorum.com/?lang=es"
         period="Sept 2020 – Mar 2022"
       >
         <p class="text-sm text-gray-700 leading-relaxed mb-5">
-          Drone-based computer vision for agriculture and renewable energy. Built recognition
-          and evaluation systems for agricultural fields and solar panel farms using
-          <strong>ROS</strong> and <strong>Python</strong>.
+          Built and deployed <strong>computer vision systems on embedded hardware</strong> for
+          real-world field operations — bridging R&D with production-grade solutions in
+          challenging environments.
         </p>
         {aeorumProjects.length > 0 && (
           <div>
             <h4 class="text-xs font-semibold text-gray-400 uppercase tracking-wider mb-3">Projects</h4>
             <div class="space-y-2">
               {aeorumProjects.map(p => (
-                <a href={`/projects#${p.id}`} class="flex items-start justify-between gap-3 p-3 rounded-lg border border-gray-100 hover:border-indigo-200 hover:bg-indigo-50/40 transition-colors group">
-                  <div class="min-w-0">
-                    <p class="text-sm font-medium text-gray-800 group-hover:text-indigo-700 transition-colors">
-                      {p.emoji} {p.title}
-                    </p>
-                    <p class="text-xs text-gray-500 mt-0.5 line-clamp-1">{p.description.slice(0, 100)}…</p>
-                  </div>
-                  <span class="text-xs text-indigo-500 whitespace-nowrap mt-0.5 flex-shrink-0">View →</span>
-                </a>
-              ))}
-            </div>
-          </div>
-        )}
-      </TimelineEntry>
-    </div>
-
-    <!-- University of Malaga -->
-    <div id="uma">
-      <TimelineEntry
-        title="R+D Developer: AI and Computer Vision"
-        subtitle="University of Malaga — Smart-Campus Projects"
-        period="Dec 2018 – Mar 2020"
-      >
-        <p class="text-sm text-gray-700 leading-relaxed mb-5">
-          Part of the Smart-Campus I R&D program — building embedded AI systems to solve
-          real urban safety problems, with research published at an international conference.
-        </p>
-        {umaProjects.length > 0 && (
-          <div>
-            <h4 class="text-xs font-semibold text-gray-400 uppercase tracking-wider mb-3">Projects</h4>
-            <div class="space-y-2">
-              {umaProjects.map(p => (
                 <a href={`/projects#${p.id}`} class="flex items-start justify-between gap-3 p-3 rounded-lg border border-gray-100 hover:border-indigo-200 hover:bg-indigo-50/40 transition-colors group">
                   <div class="min-w-0">
                     <p class="text-sm font-medium text-gray-800 group-hover:text-indigo-700 transition-colors">
@@ -206,9 +208,9 @@ const freelanceProjects = getProjectsByCompany('freelance');
         period="Mar 2019 – Oct 2019"
       >
         <p class="text-sm text-gray-700 leading-relaxed mb-5">
-          Co-founded a live marketplace startup inside the Demium incubation program,
-          acting as CTO. A great lesson in product thinking, full-stack development, and
-          knowing when to pivot.
+          Co-founded a startup and <strong>shipped the product end-to-end as CTO</strong> —
+          from architecture and development to launch. A formative experience in product
+          ownership, speed of execution, and knowing when to pivot.
         </p>
         {monkeatProjects.length > 0 && (
           <div>
@@ -231,37 +233,40 @@ const freelanceProjects = getProjectsByCompany('freelance');
       </TimelineEntry>
     </div>
 
-  </div>
-
-  <!-- Freelance Section -->
-  <div class="mt-12" id="freelance">
-    <TimelineEntry
-      title="Freelance"
-      subtitle="Independent"
-      period="Mar – Jun 2025"
-    >
-      <p class="text-sm text-gray-700 leading-relaxed mb-5">
-        Independent projects taken on outside of full-time employment.
-      </p>
-      {freelanceProjects.length > 0 && (
-        <div>
-          <h4 class="text-xs font-semibold text-gray-400 uppercase tracking-wider mb-3">Projects</h4>
-          <div class="space-y-2">
-            {freelanceProjects.map(p => (
-              <a href={`/projects#${p.id}`} class="flex items-start justify-between gap-3 p-3 rounded-lg border border-gray-100 hover:border-indigo-200 hover:bg-indigo-50/40 transition-colors group">
-                <div class="min-w-0">
-                  <p class="text-sm font-medium text-gray-800 group-hover:text-indigo-700 transition-colors">
-                    {p.emoji} {p.title}
-                  </p>
-                  <p class="text-xs text-gray-500 mt-0.5 line-clamp-1">{p.description.slice(0, 100)}…</p>
-                </div>
-                <span class="text-xs text-indigo-500 whitespace-nowrap mt-0.5 flex-shrink-0">View →</span>
-              </a>
-            ))}
+    <!-- University of Malaga -->
+    <div id="uma">
+      <TimelineEntry
+        title="R+D Developer: AI and Computer Vision"
+        subtitle="University of Malaga — Smart-Campus Projects"
+        subtitleUrl="https://www.uma.es/"
+        period="Dec 2018 – Mar 2020"
+      >
+        <p class="text-sm text-gray-700 leading-relaxed mb-5">
+          Applied <strong>research to real-world impact</strong> — designed and built AI prototypes
+          that went from academic concept to working field deployment, with results published
+          at an international conference.
+        </p>
+        {umaProjects.length > 0 && (
+          <div>
+            <h4 class="text-xs font-semibold text-gray-400 uppercase tracking-wider mb-3">Projects</h4>
+            <div class="space-y-2">
+              {umaProjects.map(p => (
+                <a href={`/projects#${p.id}`} class="flex items-start justify-between gap-3 p-3 rounded-lg border border-gray-100 hover:border-indigo-200 hover:bg-indigo-50/40 transition-colors group">
+                  <div class="min-w-0">
+                    <p class="text-sm font-medium text-gray-800 group-hover:text-indigo-700 transition-colors">
+                      {p.emoji} {p.title}
+                    </p>
+                    <p class="text-xs text-gray-500 mt-0.5 line-clamp-1">{p.description.slice(0, 100)}…</p>
+                  </div>
+                  <span class="text-xs text-indigo-500 whitespace-nowrap mt-0.5 flex-shrink-0">View →</span>
+                </a>
+              ))}
+            </div>
           </div>
-        </div>
-      )}
-    </TimelineEntry>
+        )}
+      </TimelineEntry>
+    </div>
+
   </div>
 
 </BaseLayout>

--- a/src/pages/experience.astro
+++ b/src/pages/experience.astro
@@ -1,6 +1,15 @@
 ---
 import BaseLayout from '../layouts/BaseLayout.astro';
 import TimelineEntry from '../components/TimelineEntry.astro';
+import { getProjectsByCompany } from '../data/projects';
+
+const labsterProjects   = getProjectsByCompany('labster');
+const codespaceProjects = getProjectsByCompany('codespace');
+const sngularProjects   = getProjectsByCompany('sngular');
+const aeorumProjects    = getProjectsByCompany('aeorum');
+const umaProjects       = getProjectsByCompany('uma');
+const monkeatProjects   = getProjectsByCompany('monkeat');
+const freelanceProjects = getProjectsByCompany('freelance');
 ---
 
 <BaseLayout
@@ -14,12 +23,12 @@ import TimelineEntry from '../components/TimelineEntry.astro';
 
   <!-- Jump links -->
   <div class="flex flex-wrap gap-2 mb-10">
-    <a href="#labster" class="btn-outline text-xs px-3 py-1.5">🧪 Labster</a>
+    <a href="#labster"   class="btn-outline text-xs px-3 py-1.5">🧪 Labster</a>
     <a href="#codespace" class="btn-outline text-xs px-3 py-1.5">🎓 Codespace Academy</a>
-    <a href="#sngular" class="btn-outline text-xs px-3 py-1.5">🤖 SNGULAR</a>
-    <a href="#aeorum" class="btn-outline text-xs px-3 py-1.5">🚁 Aeorum</a>
-    <a href="#uma" class="btn-outline text-xs px-3 py-1.5">🧑‍🔬 Univ. Malaga</a>
-    <a href="#monkeat" class="btn-outline text-xs px-3 py-1.5">🕵️ Monkeat</a>
+    <a href="#sngular"   class="btn-outline text-xs px-3 py-1.5">🤖 SNGULAR</a>
+    <a href="#aeorum"    class="btn-outline text-xs px-3 py-1.5">🚁 Aeorum</a>
+    <a href="#uma"       class="btn-outline text-xs px-3 py-1.5">🧑‍🔬 Univ. Malaga</a>
+    <a href="#monkeat"   class="btn-outline text-xs px-3 py-1.5">🕵️ Monkeat</a>
   </div>
 
   <div class="relative">
@@ -31,28 +40,30 @@ import TimelineEntry from '../components/TimelineEntry.astro';
         subtitle="Labster"
         period="Apr 2025 – Present"
       >
-        <p class="text-sm text-gray-700 leading-relaxed mb-4">
-          At Labster, our product is <strong>VR/3D interactive science simulations</strong> for universities and high schools —
-          immersive, high-quality, but expensive to produce. My mission is to change that ratio without touching the quality.
+        <p class="text-sm text-gray-700 leading-relaxed mb-5">
+          At Labster, our product is <strong>VR/3D interactive science simulations</strong> for
+          universities and high schools — immersive and high-quality, but expensive to produce.
+          My mission is to change that ratio without touching the quality, using AI automation
+          and low-code tooling.
         </p>
-        <div class="space-y-3">
+        {labsterProjects.length > 0 && (
           <div>
-            <h4 class="text-sm font-semibold text-gray-800 mb-1">⚡ AI Process Automation</h4>
-            <p class="text-sm text-gray-600">
-              Designed and deployed AI-powered internal workflows using <strong>Airtable</strong>, <strong>n8n</strong>,
-              <strong>Claude</strong> and <strong>OpenAI</strong> that <strong>cut course development time by 90%</strong> —
-              making each simulation faster and cheaper to produce while maintaining educational quality.
-            </p>
+            <h4 class="text-xs font-semibold text-gray-400 uppercase tracking-wider mb-3">Projects</h4>
+            <div class="space-y-2">
+              {labsterProjects.map(p => (
+                <a href={`/projects#${p.id}`} class="flex items-start justify-between gap-3 p-3 rounded-lg border border-gray-100 hover:border-indigo-200 hover:bg-indigo-50/40 transition-colors group">
+                  <div class="min-w-0">
+                    <p class="text-sm font-medium text-gray-800 group-hover:text-indigo-700 transition-colors">
+                      {p.emoji} {p.title}
+                    </p>
+                    <p class="text-xs text-gray-500 mt-0.5 line-clamp-1">{p.description.slice(0, 100)}…</p>
+                  </div>
+                  <span class="text-xs text-indigo-500 whitespace-nowrap mt-0.5 flex-shrink-0">View →</span>
+                </a>
+              ))}
+            </div>
           </div>
-          <div>
-            <h4 class="text-sm font-semibold text-gray-800 mb-1">📚 Learning Design Workflows</h4>
-            <p class="text-sm text-gray-600">
-              Built tailored AI-assisted processes for <strong>Learning Experts</strong> and <strong>Subject Matter Experts</strong>
-              — covering learning objectives, driving questions, <strong>Bloom's taxonomy</strong> levels, and Simpson's skill levels.
-              Bridging cutting-edge AI with sound pedagogical frameworks.
-            </p>
-          </div>
-        </div>
+        )}
       </TimelineEntry>
     </div>
 
@@ -63,26 +74,29 @@ import TimelineEntry from '../components/TimelineEntry.astro';
         subtitle="Codespace Academy"
         period="May 2023 – Present"
       >
-        <p class="text-sm text-gray-700 leading-relaxed mb-4">
-          Teaching the next generation of ML engineers everything I know about <strong>Machine Learning</strong>,
-          <strong>Python</strong> and <strong>MLOps</strong>. Full curriculum design and delivery for bootcamp cohorts.
+        <p class="text-sm text-gray-700 leading-relaxed mb-5">
+          Teaching the next generation of ML engineers everything I know about
+          <strong>Machine Learning</strong>, <strong>Python</strong> and <strong>MLOps</strong>.
+          Full curriculum design and delivery for bootcamp cohorts.
         </p>
-        <div class="space-y-3">
+        {codespaceProjects.length > 0 && (
           <div>
-            <h4 class="text-sm font-semibold text-gray-800 mb-1">🐍 Python & ML</h4>
-            <p class="text-sm text-gray-600">
-              Covering Python fundamentals through advanced ML: supervised and unsupervised learning, deep learning
-              with PyTorch and TensorFlow, model evaluation and deployment.
-            </p>
+            <h4 class="text-xs font-semibold text-gray-400 uppercase tracking-wider mb-3">Projects</h4>
+            <div class="space-y-2">
+              {codespaceProjects.map(p => (
+                <a href={`/projects#${p.id}`} class="flex items-start justify-between gap-3 p-3 rounded-lg border border-gray-100 hover:border-indigo-200 hover:bg-indigo-50/40 transition-colors group">
+                  <div class="min-w-0">
+                    <p class="text-sm font-medium text-gray-800 group-hover:text-indigo-700 transition-colors">
+                      {p.emoji} {p.title}
+                    </p>
+                    <p class="text-xs text-gray-500 mt-0.5 line-clamp-1">{p.description.slice(0, 100)}…</p>
+                  </div>
+                  <span class="text-xs text-indigo-500 whitespace-nowrap mt-0.5 flex-shrink-0">View →</span>
+                </a>
+              ))}
+            </div>
           </div>
-          <div>
-            <h4 class="text-sm font-semibold text-gray-800 mb-1">🚀 MLOps</h4>
-            <p class="text-sm text-gray-600">
-              Teaching production best practices: experiment tracking with <strong>MLflow</strong>, containerization with
-              <strong>Docker</strong>, CI/CD pipelines, and model serving.
-            </p>
-          </div>
-        </div>
+        )}
       </TimelineEntry>
     </div>
 
@@ -93,60 +107,29 @@ import TimelineEntry from '../components/TimelineEntry.astro';
         subtitle="SNGULAR"
         period="Mar 2022 – Apr 2025"
       >
-        <p class="text-sm text-gray-700 leading-relaxed mb-4">
-          Worked across multiple high-impact AI products in different industries — from retail and sports to real estate and
-          banking. Each project had a clear product goal and a tight delivery timeline.
+        <p class="text-sm text-gray-700 leading-relaxed mb-5">
+          Worked across multiple high-impact AI products in different industries — from retail
+          and sports to real estate and banking. Each project had a clear product goal and a
+          tight delivery timeline.
         </p>
-        <div class="space-y-4">
-
-          <div class="pl-3 border-l-2 border-indigo-200">
-            <h4 class="text-sm font-semibold text-gray-800 mb-1">🏦 Banco Santander — Internal AI MVP <span class="text-xs font-normal text-indigo-600 ml-1">Dec 2024 – Mar 2025</span></h4>
-            <p class="text-sm text-gray-600">
-              Designed an MVP concept for <strong>safe internal AI adoption</strong> at a major financial institution.
-              Researched and synthesized how leading global companies govern AI internally — translating those patterns
-              into an actionable enterprise-ready proposal.
-            </p>
+        {sngularProjects.length > 0 && (
+          <div>
+            <h4 class="text-xs font-semibold text-gray-400 uppercase tracking-wider mb-3">Projects</h4>
+            <div class="space-y-2">
+              {sngularProjects.map(p => (
+                <a href={`/projects#${p.id}`} class="flex items-start justify-between gap-3 p-3 rounded-lg border border-gray-100 hover:border-indigo-200 hover:bg-indigo-50/40 transition-colors group">
+                  <div class="min-w-0">
+                    <p class="text-sm font-medium text-gray-800 group-hover:text-indigo-700 transition-colors">
+                      {p.emoji} {p.title}
+                    </p>
+                    <p class="text-xs text-gray-500 mt-0.5 line-clamp-1">{p.description.slice(0, 100)}…</p>
+                  </div>
+                  <span class="text-xs text-indigo-500 whitespace-nowrap mt-0.5 flex-shrink-0">View →</span>
+                </a>
+              ))}
+            </div>
           </div>
-
-          <div class="pl-3 border-l-2 border-indigo-200">
-            <h4 class="text-sm font-semibold text-gray-800 mb-1">🏠 Real Estate AI — Document Analysis Platform <span class="text-xs font-normal text-indigo-600 ml-1">2024</span></h4>
-            <p class="text-sm text-gray-600">
-              Built an end-to-end AI pipeline that ingested <strong>legal and technical property documents</strong> and
-              extracted structured data into a database — enabling fast, automated real estate analysis that previously
-              required manual expert review.
-            </p>
-          </div>
-
-          <div class="pl-3 border-l-2 border-indigo-200">
-            <h4 class="text-sm font-semibold text-gray-800 mb-1">🏀 The Embassy / KM Calderón — Basketball AI <span class="text-xs font-normal text-indigo-600 ml-1">Summer 2023</span></h4>
-            <p class="text-sm text-gray-600">
-              Developed a <strong>real-time AI basketball match evaluation tool</strong> for{' '}
-              <a href="https://en.wikipedia.org/wiki/Carlos_Jim%C3%A9nez_Calder%C3%B3n" target="_blank" rel="noopener noreferrer" class="text-indigo-600 hover:underline">KM Calderón</a>'s
-              The Embassy academy (Spanish NBA champion and former NBA player). Live player and ball tracking
-              with on-court performance analytics.
-            </p>
-          </div>
-
-          <div class="pl-3 border-l-2 border-indigo-200">
-            <h4 class="text-sm font-semibold text-gray-800 mb-1">🎾 PADMI — Padel AI Startup <span class="text-xs font-normal text-indigo-600 ml-1">Jan – Jul 2023</span></h4>
-            <p class="text-sm text-gray-600">
-              6-month intensive sprint: built the <strong>initial AI system from scratch</strong> and launched a fully working
-              prototype for 3D computer vision padel performance analysis.{' '}
-              <a href="https://www.padmi.es/" target="_blank" rel="noopener noreferrer" class="text-indigo-600 hover:underline">PADMI</a>{' '}
-              went from zero to a demo-ready product using multi-camera 3D tracking and biomechanical metrics.
-            </p>
-          </div>
-
-          <div class="pl-3 border-l-2 border-indigo-200">
-            <h4 class="text-sm font-semibold text-gray-800 mb-1">🛒 Mercadona Tech — Cashierless Store MVP <span class="text-xs font-normal text-indigo-600 ml-1">Mar – Dec 2022</span></h4>
-            <p class="text-sm text-gray-600">
-              Developed a cashierless retail store MVP for Spain's largest supermarket chain using
-              <strong>3D Computer Vision</strong> and <strong>AI</strong> — person tracking, product detection,
-              and automated checkout without any manual intervention.
-            </p>
-          </div>
-
-        </div>
+        )}
       </TimelineEntry>
     </div>
 
@@ -157,33 +140,29 @@ import TimelineEntry from '../components/TimelineEntry.astro';
         subtitle="Aeorum"
         period="Sept 2020 – Mar 2022"
       >
-        <p class="text-sm text-gray-700 leading-relaxed mb-4">
-          Drone-based computer vision for agriculture and renewable energy. Built recognition and evaluation
-          systems for agricultural fields and solar panel farms using <strong>ROS</strong> and <strong>Python</strong>.
+        <p class="text-sm text-gray-700 leading-relaxed mb-5">
+          Drone-based computer vision for agriculture and renewable energy. Built recognition
+          and evaluation systems for agricultural fields and solar panel farms using
+          <strong>ROS</strong> and <strong>Python</strong>.
         </p>
-        <div class="space-y-3">
+        {aeorumProjects.length > 0 && (
           <div>
-            <h4 class="text-sm font-semibold text-gray-800 mb-1">🤖 Deep Learning on Drones</h4>
-            <p class="text-sm text-gray-600">
-              Implementing perception in unmanned aerial vehicles using <strong>YOLO</strong> and <strong>SSD-MobileNet</strong>.
-              Training and deploying models on GPU and embedded systems with <strong>C++</strong>, <strong>Docker</strong>,
-              <strong>Python</strong> and <strong>ROS</strong>.
-            </p>
+            <h4 class="text-xs font-semibold text-gray-400 uppercase tracking-wider mb-3">Projects</h4>
+            <div class="space-y-2">
+              {aeorumProjects.map(p => (
+                <a href={`/projects#${p.id}`} class="flex items-start justify-between gap-3 p-3 rounded-lg border border-gray-100 hover:border-indigo-200 hover:bg-indigo-50/40 transition-colors group">
+                  <div class="min-w-0">
+                    <p class="text-sm font-medium text-gray-800 group-hover:text-indigo-700 transition-colors">
+                      {p.emoji} {p.title}
+                    </p>
+                    <p class="text-xs text-gray-500 mt-0.5 line-clamp-1">{p.description.slice(0, 100)}…</p>
+                  </div>
+                  <span class="text-xs text-indigo-500 whitespace-nowrap mt-0.5 flex-shrink-0">View →</span>
+                </a>
+              ))}
+            </div>
           </div>
-          <div>
-            <h4 class="text-sm font-semibold text-gray-800 mb-1">🌱 Agricultural & Solar Panel Analysis</h4>
-            <p class="text-sm text-gray-600">
-              Multispectral orthomosaics for crop health assessment; thermal anomaly detection on photovoltaic cells.
-              Developed a proprietary solution for generating GeoTIFFs from multiple aerial cameras.
-            </p>
-          </div>
-          <div>
-            <h4 class="text-sm font-semibold text-gray-800 mb-1">🏗️ Structure from Motion</h4>
-            <p class="text-sm text-gray-600">
-              Building 3D point cloud reconstructions from 2D drone image sequences.
-            </p>
-          </div>
-        </div>
+        )}
       </TimelineEntry>
     </div>
 
@@ -194,34 +173,28 @@ import TimelineEntry from '../components/TimelineEntry.astro';
         subtitle="University of Malaga — Smart-Campus Projects"
         period="Dec 2018 – Mar 2020"
       >
-        <p class="text-sm text-gray-700 leading-relaxed mb-4">
-          Part of the Smart-Campus I projects (<a href="https://github.com/Matesanz/DIAS2P" target="_blank" rel="noopener noreferrer" class="text-indigo-600 hover:underline">DIAS2P</a> and{' '}
-          <a href="https://github.com/Matesanz/StreetQR" target="_blank" rel="noopener noreferrer" class="text-indigo-600 hover:underline">StreetQR</a>):
-          built a solution to reduce car-pedestrian collisions by attaching embedded systems running object detection
-          neural networks into traffic signs. The{' '}
-          <a href="https://riuma.uma.es/xmlui/bitstream/handle/10630/18443/CIPI_2019_paper_37.pdf" target="_blank" rel="noopener noreferrer" class="text-indigo-600 hover:underline">paper was published at CIPI 2019</a>.
+        <p class="text-sm text-gray-700 leading-relaxed mb-5">
+          Part of the Smart-Campus I R&D program — building embedded AI systems to solve
+          real urban safety problems, with research published at an international conference.
         </p>
-        <div class="space-y-3">
+        {umaProjects.length > 0 && (
           <div>
-            <h4 class="text-sm font-semibold text-gray-800 mb-1">🤖 Deep Learning</h4>
-            <p class="text-sm text-gray-600">
-              Training YOLO, SSD-MobileNet and Mask-RCNN for real-time pedestrian-collision detection.
-              Deployment on <strong>Jetson Nano</strong>. Object tracking with the Hungarian Algorithm.
-            </p>
+            <h4 class="text-xs font-semibold text-gray-400 uppercase tracking-wider mb-3">Projects</h4>
+            <div class="space-y-2">
+              {umaProjects.map(p => (
+                <a href={`/projects#${p.id}`} class="flex items-start justify-between gap-3 p-3 rounded-lg border border-gray-100 hover:border-indigo-200 hover:bg-indigo-50/40 transition-colors group">
+                  <div class="min-w-0">
+                    <p class="text-sm font-medium text-gray-800 group-hover:text-indigo-700 transition-colors">
+                      {p.emoji} {p.title}
+                    </p>
+                    <p class="text-xs text-gray-500 mt-0.5 line-clamp-1">{p.description.slice(0, 100)}…</p>
+                  </div>
+                  <span class="text-xs text-indigo-500 whitespace-nowrap mt-0.5 flex-shrink-0">View →</span>
+                </a>
+              ))}
+            </div>
           </div>
-          <div>
-            <h4 class="text-sm font-semibold text-gray-800 mb-1">⚡ Electronics</h4>
-            <p class="text-sm text-gray-600">
-              Designing electronic architecture to run actuators (sound and lights) warning drivers of pedestrian presence.
-            </p>
-          </div>
-          <div>
-            <h4 class="text-sm font-semibold text-gray-800 mb-1">📊 Data</h4>
-            <p class="text-sm text-gray-600">
-              Built an API using <strong>Firebase</strong> to record statistics on car and pedestrian crossings.
-            </p>
-          </div>
-        </div>
+        )}
       </TimelineEntry>
     </div>
 
@@ -232,43 +205,63 @@ import TimelineEntry from '../components/TimelineEntry.astro';
         subtitle="Monkeat — Startup (Demium Incubation Program)"
         period="Mar 2019 – Oct 2019"
       >
-        <p class="text-sm text-gray-700 leading-relaxed">
-          Co-founded <strong>Monkeat</strong>, a live-time marketplace helping pubs boost customer acquisition through
-          real-time offers. As CTO, developed a full <strong>Progressive Web App</strong> using <strong>Vue + Ionic</strong>,
-          <strong>MongoDB</strong>, <strong>Flask</strong> and <strong>Firebase</strong>. We could not finally validate our
-          MVP and closed the project after a few months — but it was a great learning experience!
+        <p class="text-sm text-gray-700 leading-relaxed mb-5">
+          Co-founded a live marketplace startup inside the Demium incubation program,
+          acting as CTO. A great lesson in product thinking, full-stack development, and
+          knowing when to pivot.
         </p>
+        {monkeatProjects.length > 0 && (
+          <div>
+            <h4 class="text-xs font-semibold text-gray-400 uppercase tracking-wider mb-3">Projects</h4>
+            <div class="space-y-2">
+              {monkeatProjects.map(p => (
+                <a href={`/projects#${p.id}`} class="flex items-start justify-between gap-3 p-3 rounded-lg border border-gray-100 hover:border-indigo-200 hover:bg-indigo-50/40 transition-colors group">
+                  <div class="min-w-0">
+                    <p class="text-sm font-medium text-gray-800 group-hover:text-indigo-700 transition-colors">
+                      {p.emoji} {p.title}
+                    </p>
+                    <p class="text-xs text-gray-500 mt-0.5 line-clamp-1">{p.description.slice(0, 100)}…</p>
+                  </div>
+                  <span class="text-xs text-indigo-500 whitespace-nowrap mt-0.5 flex-shrink-0">View →</span>
+                </a>
+              ))}
+            </div>
+          </div>
+        )}
       </TimelineEntry>
     </div>
 
   </div>
 
   <!-- Freelance Section -->
-  <div class="mt-12">
-    <h2 class="text-2xl font-bold text-gray-900 mb-2">🧑‍💻 Freelance</h2>
-    <p class="text-gray-500 mb-8">Independent projects I've taken on alongside my main roles.</p>
-
-    <div class="relative">
-      <div class="relative pl-10 pb-8">
-        <!-- Vertical line -->
-        <div class="absolute left-4 top-6 bottom-0 w-0.5 bg-indigo-100"></div>
-        <!-- Dot -->
-        <div class="absolute left-2 top-2 w-4 h-4 rounded-full bg-indigo-500 border-2 border-white shadow-sm"></div>
-
-        <div class="card">
-          <div class="flex flex-col sm:flex-row sm:items-start sm:justify-between gap-1 mb-2">
-            <h3 class="text-lg font-semibold text-gray-900">Video Movement Prediction Model</h3>
-            <span class="text-sm text-indigo-600 font-medium whitespace-nowrap">Mar – Jun 2025</span>
+  <div class="mt-12" id="freelance">
+    <TimelineEntry
+      title="Freelance"
+      subtitle="Independent"
+      period="Mar – Jun 2025"
+    >
+      <p class="text-sm text-gray-700 leading-relaxed mb-5">
+        Independent projects taken on outside of full-time employment.
+      </p>
+      {freelanceProjects.length > 0 && (
+        <div>
+          <h4 class="text-xs font-semibold text-gray-400 uppercase tracking-wider mb-3">Projects</h4>
+          <div class="space-y-2">
+            {freelanceProjects.map(p => (
+              <a href={`/projects#${p.id}`} class="flex items-start justify-between gap-3 p-3 rounded-lg border border-gray-100 hover:border-indigo-200 hover:bg-indigo-50/40 transition-colors group">
+                <div class="min-w-0">
+                  <p class="text-sm font-medium text-gray-800 group-hover:text-indigo-700 transition-colors">
+                    {p.emoji} {p.title}
+                  </p>
+                  <p class="text-xs text-gray-500 mt-0.5 line-clamp-1">{p.description.slice(0, 100)}…</p>
+                </div>
+                <span class="text-xs text-indigo-500 whitespace-nowrap mt-0.5 flex-shrink-0">View →</span>
+              </a>
+            ))}
           </div>
-          <p class="text-sm font-medium text-gray-500 mb-3">Independent · Computer Vision & Deep Learning</p>
-          <p class="text-sm text-gray-700 leading-relaxed">
-            Designed and trained a <strong>PyTorch-based deep learning model</strong> for video movement prediction —
-            from architecture design and dataset preparation through to training and evaluation.
-            <span class="text-gray-400 italic ml-1">(NDA — further details confidential.)</span>
-          </p>
         </div>
-      </div>
-    </div>
+      )}
+    </TimelineEntry>
   </div>
 
 </BaseLayout>

--- a/src/pages/experience.astro
+++ b/src/pages/experience.astro
@@ -5,7 +5,7 @@ import TimelineEntry from '../components/TimelineEntry.astro';
 
 <BaseLayout
   title="Experience — Andrés Matesanz"
-  description="Professional experience of Andrés Matesanz: R&D Developer in AI, Computer Vision and Data Engineering."
+  description="Professional experience of Andrés Matesanz: AI Engineer, Computer Vision Developer, and Bootcamp Instructor."
 >
   <h1 class="text-3xl font-bold text-gray-900 mb-2">🧑‍💻 Professional Experience</h1>
   <p class="text-gray-500 mb-10">
@@ -14,56 +14,173 @@ import TimelineEntry from '../components/TimelineEntry.astro';
 
   <!-- Jump links -->
   <div class="flex flex-wrap gap-2 mb-10">
-    <a href="#aeorum" class="btn-outline text-xs px-3 py-1.5">🧑‍🔬 Aeorum</a>
+    <a href="#labster" class="btn-outline text-xs px-3 py-1.5">🧪 Labster</a>
+    <a href="#codespace" class="btn-outline text-xs px-3 py-1.5">🎓 Codespace Academy</a>
+    <a href="#sngular" class="btn-outline text-xs px-3 py-1.5">🤖 SNGULAR</a>
+    <a href="#aeorum" class="btn-outline text-xs px-3 py-1.5">🚁 Aeorum</a>
     <a href="#uma" class="btn-outline text-xs px-3 py-1.5">🧑‍🔬 Univ. Malaga</a>
     <a href="#monkeat" class="btn-outline text-xs px-3 py-1.5">🕵️ Monkeat</a>
   </div>
 
   <div class="relative">
 
-    <!-- Aeorum -->
-    <div id="aeorum">
+    <!-- Labster -->
+    <div id="labster">
       <TimelineEntry
-        title="R+D Developer: Data, AI and Computer Vision"
-        subtitle="Aeorum"
-        period="Aug 2020 – Present"
+        title="AI Engineer"
+        subtitle="Labster"
+        period="Apr 2025 – Present"
       >
         <p class="text-sm text-gray-700 leading-relaxed mb-4">
-          Developing solutions across multiple R&D fields using deep learning, data engineering, and computer vision.
+          At Labster, our product is <strong>VR/3D interactive science simulations</strong> for universities and high schools —
+          immersive, high-quality, but expensive to produce. My mission is to change that ratio without touching the quality.
         </p>
         <div class="space-y-3">
           <div>
-            <h4 class="text-sm font-semibold text-gray-800 mb-1">🤖 Deep Learning</h4>
+            <h4 class="text-sm font-semibold text-gray-800 mb-1">⚡ AI Process Automation</h4>
             <p class="text-sm text-gray-600">
-              Implementing perception in unmanned aerial vehicles using <strong>deep neural networks</strong> (YOLO, SSD-MobileNet)
-              and classic computer vision. Training and deploying models on GPU and embedded systems with <strong>C++</strong>,
-              <strong>Docker</strong>, <strong>Python</strong> and <strong>ROS</strong>.
+              Designed and deployed AI-powered internal workflows using <strong>Airtable</strong>, <strong>n8n</strong>,
+              <strong>Claude</strong> and <strong>OpenAI</strong> that <strong>cut course development time by 90%</strong> —
+              making each simulation faster and cheaper to produce while maintaining educational quality.
             </p>
           </div>
           <div>
-            <h4 class="text-sm font-semibold text-gray-800 mb-1">📊 Data Engineering</h4>
+            <h4 class="text-sm font-semibold text-gray-800 mb-1">📚 Learning Design Workflows</h4>
             <p class="text-sm text-gray-600">
-              Built the company's data layer from scratch: big data processing with <strong>Spark</strong>, real-time processing
-              with <strong>Kafka</strong>, and database design with <strong>MongoDB</strong>, <strong>MySQL</strong> and <strong>Redis</strong>.
+              Built tailored AI-assisted processes for <strong>Learning Experts</strong> and <strong>Subject Matter Experts</strong>
+              — covering learning objectives, driving questions, <strong>Bloom's taxonomy</strong> levels, and Simpson's skill levels.
+              Bridging cutting-edge AI with sound pedagogical frameworks.
+            </p>
+          </div>
+        </div>
+      </TimelineEntry>
+    </div>
+
+    <!-- Codespace Academy -->
+    <div id="codespace">
+      <TimelineEntry
+        title="Bootcamp Instructor"
+        subtitle="Codespace Academy"
+        period="May 2023 – Present"
+      >
+        <p class="text-sm text-gray-700 leading-relaxed mb-4">
+          Teaching the next generation of ML engineers everything I know about <strong>Machine Learning</strong>,
+          <strong>Python</strong> and <strong>MLOps</strong>. Full curriculum design and delivery for bootcamp cohorts.
+        </p>
+        <div class="space-y-3">
+          <div>
+            <h4 class="text-sm font-semibold text-gray-800 mb-1">🐍 Python & ML</h4>
+            <p class="text-sm text-gray-600">
+              Covering Python fundamentals through advanced ML: supervised and unsupervised learning, deep learning
+              with PyTorch and TensorFlow, model evaluation and deployment.
+            </p>
+          </div>
+          <div>
+            <h4 class="text-sm font-semibold text-gray-800 mb-1">🚀 MLOps</h4>
+            <p class="text-sm text-gray-600">
+              Teaching production best practices: experiment tracking with <strong>MLflow</strong>, containerization with
+              <strong>Docker</strong>, CI/CD pipelines, and model serving.
+            </p>
+          </div>
+        </div>
+      </TimelineEntry>
+    </div>
+
+    <!-- SNGULAR -->
+    <div id="sngular">
+      <TimelineEntry
+        title="Artificial Intelligence Engineer"
+        subtitle="SNGULAR"
+        period="Mar 2022 – Apr 2025"
+      >
+        <p class="text-sm text-gray-700 leading-relaxed mb-4">
+          Worked across multiple high-impact AI products in different industries — from retail and sports to real estate and
+          banking. Each project had a clear product goal and a tight delivery timeline.
+        </p>
+        <div class="space-y-4">
+
+          <div class="pl-3 border-l-2 border-indigo-200">
+            <h4 class="text-sm font-semibold text-gray-800 mb-1">🏦 Banco Santander — Internal AI MVP <span class="text-xs font-normal text-indigo-600 ml-1">Dec 2024 – Mar 2025</span></h4>
+            <p class="text-sm text-gray-600">
+              Designed an MVP concept for <strong>safe internal AI adoption</strong> at a major financial institution.
+              Researched and synthesized how leading global companies govern AI internally — translating those patterns
+              into an actionable enterprise-ready proposal.
+            </p>
+          </div>
+
+          <div class="pl-3 border-l-2 border-indigo-200">
+            <h4 class="text-sm font-semibold text-gray-800 mb-1">🏠 Real Estate AI — Document Analysis Platform <span class="text-xs font-normal text-indigo-600 ml-1">2024</span></h4>
+            <p class="text-sm text-gray-600">
+              Built an end-to-end AI pipeline that ingested <strong>legal and technical property documents</strong> and
+              extracted structured data into a database — enabling fast, automated real estate analysis that previously
+              required manual expert review.
+            </p>
+          </div>
+
+          <div class="pl-3 border-l-2 border-indigo-200">
+            <h4 class="text-sm font-semibold text-gray-800 mb-1">🏀 The Embassy / KM Calderón — Basketball AI <span class="text-xs font-normal text-indigo-600 ml-1">Summer 2023</span></h4>
+            <p class="text-sm text-gray-600">
+              Developed a <strong>real-time AI basketball match evaluation tool</strong> for{' '}
+              <a href="https://en.wikipedia.org/wiki/Carlos_Jim%C3%A9nez_Calder%C3%B3n" target="_blank" rel="noopener noreferrer" class="text-indigo-600 hover:underline">KM Calderón</a>'s
+              The Embassy academy (Spanish NBA champion and former NBA player). Live player and ball tracking
+              with on-court performance analytics.
+            </p>
+          </div>
+
+          <div class="pl-3 border-l-2 border-indigo-200">
+            <h4 class="text-sm font-semibold text-gray-800 mb-1">🎾 PADMI — Padel AI Startup <span class="text-xs font-normal text-indigo-600 ml-1">Jan – Jul 2023</span></h4>
+            <p class="text-sm text-gray-600">
+              6-month intensive sprint: built the <strong>initial AI system from scratch</strong> and launched a fully working
+              prototype for 3D computer vision padel performance analysis.{' '}
+              <a href="https://www.padmi.es/" target="_blank" rel="noopener noreferrer" class="text-indigo-600 hover:underline">PADMI</a>{' '}
+              went from zero to a demo-ready product using multi-camera 3D tracking and biomechanical metrics.
+            </p>
+          </div>
+
+          <div class="pl-3 border-l-2 border-indigo-200">
+            <h4 class="text-sm font-semibold text-gray-800 mb-1">🛒 Mercadona Tech — Cashierless Store MVP <span class="text-xs font-normal text-indigo-600 ml-1">Mar – Dec 2022</span></h4>
+            <p class="text-sm text-gray-600">
+              Developed a cashierless retail store MVP for Spain's largest supermarket chain using
+              <strong>3D Computer Vision</strong> and <strong>AI</strong> — person tracking, product detection,
+              and automated checkout without any manual intervention.
+            </p>
+          </div>
+
+        </div>
+      </TimelineEntry>
+    </div>
+
+    <!-- Aeorum -->
+    <div id="aeorum">
+      <TimelineEntry
+        title="Computer Vision Developer"
+        subtitle="Aeorum"
+        period="Sept 2020 – Mar 2022"
+      >
+        <p class="text-sm text-gray-700 leading-relaxed mb-4">
+          Drone-based computer vision for agriculture and renewable energy. Built recognition and evaluation
+          systems for agricultural fields and solar panel farms using <strong>ROS</strong> and <strong>Python</strong>.
+        </p>
+        <div class="space-y-3">
+          <div>
+            <h4 class="text-sm font-semibold text-gray-800 mb-1">🤖 Deep Learning on Drones</h4>
+            <p class="text-sm text-gray-600">
+              Implementing perception in unmanned aerial vehicles using <strong>YOLO</strong> and <strong>SSD-MobileNet</strong>.
+              Training and deploying models on GPU and embedded systems with <strong>C++</strong>, <strong>Docker</strong>,
+              <strong>Python</strong> and <strong>ROS</strong>.
+            </p>
+          </div>
+          <div>
+            <h4 class="text-sm font-semibold text-gray-800 mb-1">🌱 Agricultural & Solar Panel Analysis</h4>
+            <p class="text-sm text-gray-600">
+              Multispectral orthomosaics for crop health assessment; thermal anomaly detection on photovoltaic cells.
+              Developed a proprietary solution for generating GeoTIFFs from multiple aerial cameras.
             </p>
           </div>
           <div>
             <h4 class="text-sm font-semibold text-gray-800 mb-1">🏗️ Structure from Motion</h4>
             <p class="text-sm text-gray-600">
-              Building 3D point cloud reconstructions from 2D drone images.
-            </p>
-          </div>
-          <div>
-            <h4 class="text-sm font-semibold text-gray-800 mb-1">🌱 Plant Health Analysis</h4>
-            <p class="text-sm text-gray-600">
-              Research project using special cameras to retrieve field health status — building wavelength orthomosaics
-              for agronomists.
-            </p>
-          </div>
-          <div>
-            <h4 class="text-sm font-semibold text-gray-800 mb-1">☀️ Photovoltaic Panels Analysis</h4>
-            <p class="text-sm text-gray-600">
-              Research project detecting anomalous thermal registries on photovoltaic cells using infrared cameras.
+              Building 3D point cloud reconstructions from 2D drone image sequences.
             </p>
           </div>
         </div>
@@ -125,4 +242,33 @@ import TimelineEntry from '../components/TimelineEntry.astro';
     </div>
 
   </div>
+
+  <!-- Freelance Section -->
+  <div class="mt-12">
+    <h2 class="text-2xl font-bold text-gray-900 mb-2">🧑‍💻 Freelance</h2>
+    <p class="text-gray-500 mb-8">Independent projects I've taken on alongside my main roles.</p>
+
+    <div class="relative">
+      <div class="relative pl-10 pb-8">
+        <!-- Vertical line -->
+        <div class="absolute left-4 top-6 bottom-0 w-0.5 bg-indigo-100"></div>
+        <!-- Dot -->
+        <div class="absolute left-2 top-2 w-4 h-4 rounded-full bg-indigo-500 border-2 border-white shadow-sm"></div>
+
+        <div class="card">
+          <div class="flex flex-col sm:flex-row sm:items-start sm:justify-between gap-1 mb-2">
+            <h3 class="text-lg font-semibold text-gray-900">Video Movement Prediction Model</h3>
+            <span class="text-sm text-indigo-600 font-medium whitespace-nowrap">Mar – Jun 2025</span>
+          </div>
+          <p class="text-sm font-medium text-gray-500 mb-3">Independent · Computer Vision & Deep Learning</p>
+          <p class="text-sm text-gray-700 leading-relaxed">
+            Designed and trained a <strong>PyTorch-based deep learning model</strong> for video movement prediction —
+            from architecture design and dataset preparation through to training and evaluation.
+            <span class="text-gray-400 italic ml-1">(NDA — further details confidential.)</span>
+          </p>
+        </div>
+      </div>
+    </div>
+  </div>
+
 </BaseLayout>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -60,6 +60,17 @@ import BaseLayout from '../layouts/BaseLayout.astro';
           </svg>
           Twitter
         </a>
+        <a
+          href="https://medium.com/@matesanz.cuadrado"
+          target="_blank"
+          rel="noopener noreferrer"
+          class="btn-outline"
+        >
+          <svg class="w-4 h-4" fill="currentColor" viewBox="0 0 24 24">
+            <path d="M13.54 12a6.8 6.8 0 11-6.77-6.82A6.77 6.77 0 0113.54 12zm7.42 0c0 3.54-1.51 6.42-3.38 6.42S14.2 15.54 14.2 12s1.51-6.42 3.38-6.42 3.38 2.88 3.38 6.42zm3.04 0c0 3.25-.31 5.88-.7 5.88s-.7-2.63-.7-5.88.31-5.88.7-5.88.7 2.63.7 5.88z" />
+          </svg>
+          Medium
+        </a>
       </div>
     </div>
   </section>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -50,24 +50,35 @@ import SkillBadges from '../components/SkillBadges.astro';
           </svg>
           GitHub
         </a>
+        <a
+          href="https://twitter.com/aimatesanz"
+          target="_blank"
+          rel="noopener noreferrer"
+          class="btn-outline"
+        >
+          <svg class="w-4 h-4" fill="currentColor" viewBox="0 0 24 24">
+            <path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-5.214-6.817L4.99 21.75H1.68l7.73-8.835L1.254 2.25H8.08l4.713 6.231zm-1.161 17.52h1.833L7.084 4.126H5.117z" />
+          </svg>
+          Twitter
+        </a>
       </div>
     </div>
   </section>
 
   <!-- About Section -->
-  <section class="py-6">
-    <div class="card">
-      <p class="text-gray-700 leading-relaxed text-lg">
-        I am an <strong>AI & Automation Engineer</strong> currently building at <strong>Labster</strong>. 
-        I believe technology is a tool, not the goal. My focus is on solving business problems 
-        through automation and <strong>AI when it makes sense</strong>, prioritizing product impact and 
-        operational efficiency over unnecessary complexity.
+  <section class="py-4">
+    <div class="card p-5">
+      <p class="text-gray-700 leading-relaxed text-base">
+        I am an <strong>AI & Automation Engineer</strong> building at <strong>Labster</strong>. 
+        I believe technology is a tool, not the goal. I solve business problems 
+        through <strong>AI & Automation</strong> when it makes sense, prioritizing impact and 
+        efficiency over complexity.
       </p>
     </div>
   </section>
 
   <!-- Quick nav cards -->
-  <section class="py-6 grid grid-cols-2 sm:grid-cols-3 gap-4">
+  <section class="py-4 grid grid-cols-2 sm:grid-cols-3 gap-3">
     <a href="/education" class="card hover:border-indigo-300 hover:shadow-md transition-all group">
       <div class="text-2xl mb-2">🎓</div>
       <h3 class="font-semibold text-gray-900 group-hover:text-indigo-600 transition-colors">Education</h3>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -77,7 +77,7 @@ import SkillBadges from '../components/SkillBadges.astro';
   </section>
 
   <!-- Quick nav cards -->
-  <section class="py-6 grid grid-cols-2 lg:grid-cols-4 gap-4">
+  <section class="py-6 grid grid-cols-2 sm:grid-cols-3 gap-4">
     <a href="/education" class="card hover:border-indigo-300 hover:shadow-md transition-all group">
       <div class="text-2xl mb-2">🎓</div>
       <h3 class="font-semibold text-gray-900 group-hover:text-indigo-600 transition-colors">Education</h3>
@@ -87,6 +87,11 @@ import SkillBadges from '../components/SkillBadges.astro';
       <div class="text-2xl mb-2">👷</div>
       <h3 class="font-semibold text-gray-900 group-hover:text-indigo-600 transition-colors">Experience</h3>
       <p class="text-sm text-gray-500 mt-1">Professional career</p>
+    </a>
+    <a href="/projects" class="card hover:border-indigo-300 hover:shadow-md transition-all group">
+      <div class="text-2xl mb-2">📂</div>
+      <h3 class="font-semibold text-gray-900 group-hover:text-indigo-600 transition-colors">Projects</h3>
+      <p class="text-sm text-gray-500 mt-1">What I've built</p>
     </a>
     <a href="/talks" class="card hover:border-indigo-300 hover:shadow-md transition-all group">
       <div class="text-2xl mb-2">🗣️</div>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -77,7 +77,7 @@ import SkillBadges from '../components/SkillBadges.astro';
   </section>
 
   <!-- Quick nav cards -->
-  <section class="py-6 grid sm:grid-cols-3 gap-4">
+  <section class="py-6 grid grid-cols-2 lg:grid-cols-4 gap-4">
     <a href="/education" class="card hover:border-indigo-300 hover:shadow-md transition-all group">
       <div class="text-2xl mb-2">🎓</div>
       <h3 class="font-semibold text-gray-900 group-hover:text-indigo-600 transition-colors">Education</h3>
@@ -92,6 +92,11 @@ import SkillBadges from '../components/SkillBadges.astro';
       <div class="text-2xl mb-2">🗣️</div>
       <h3 class="font-semibold text-gray-900 group-hover:text-indigo-600 transition-colors">Talks</h3>
       <p class="text-sm text-gray-500 mt-1">Conferences & workshops</p>
+    </a>
+    <a href="/cv" class="card hover:border-indigo-300 hover:shadow-md transition-all group">
+      <div class="text-2xl mb-2">📄</div>
+      <h3 class="font-semibold text-gray-900 group-hover:text-indigo-600 transition-colors">CV</h3>
+      <p class="text-sm text-gray-500 mt-1">Recruiter-friendly summary</p>
     </a>
   </section>
 

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -4,8 +4,8 @@ import SkillBadges from '../components/SkillBadges.astro';
 ---
 
 <BaseLayout
-  title="Andrés Matesanz — AI & Python Developer"
-  description="Python R&D Software Developer specializing in AI, Data and Computer Vision. Co-founder of the Malaga AI Association."
+  title="Andrés Matesanz — AI & Automation Engineer"
+  description="AI & Automation Engineer at Labster specializing in product-first solutions, data automation, and efficient AI integration."
 >
   <!-- Hero Section -->
   <section class="py-12 text-center">
@@ -22,8 +22,8 @@ import SkillBadges from '../components/SkillBadges.astro';
         <h1 class="text-4xl font-bold text-gray-900 mb-2">
           👋 Hi, I'm Andrés Matesanz
         </h1>
-        <p class="text-xl text-indigo-600 font-medium">Python R&D Software Developer</p>
-        <p class="text-gray-500 mt-1">AI · Data · Computer Vision · Robotics</p>
+        <p class="text-xl text-indigo-600 font-medium">AI & Automation Engineer</p>
+        <p class="text-gray-500 mt-1">Product First · Automation · AI · Python</p>
       </div>
 
       <!-- Social buttons -->
@@ -50,17 +50,6 @@ import SkillBadges from '../components/SkillBadges.astro';
           </svg>
           GitHub
         </a>
-        <a
-          href="https://twitter.com/aimatesanz"
-          target="_blank"
-          rel="noopener noreferrer"
-          class="btn-outline"
-        >
-          <svg class="w-4 h-4" fill="currentColor" viewBox="0 0 24 24">
-            <path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-5.214-6.817L4.99 21.75H1.68l7.73-8.835L1.254 2.25H8.08l4.713 6.231zm-1.161 17.52h1.833L7.084 4.126H5.117z" />
-          </svg>
-          Twitter
-        </a>
       </div>
     </div>
   </section>
@@ -69,9 +58,10 @@ import SkillBadges from '../components/SkillBadges.astro';
   <section class="py-6">
     <div class="card">
       <p class="text-gray-700 leading-relaxed text-lg">
-        I'm a <strong>Python R&D Software Developer</strong> who takes new ideas into practice — and I really enjoy it! 😁
-        I give talks about <strong>Artificial Intelligence</strong> and I'm deeply interested in <strong>AI, Data and Robotics</strong> 🦾.
-        I also like board games, doing sports, playing guitar, and just being with my friends.
+        I am an <strong>AI & Automation Engineer</strong> currently building at <strong>Labster</strong>. 
+        I believe technology is a tool, not the goal. My focus is on solving business problems 
+        through automation and <strong>AI when it makes sense</strong>, prioritizing product impact and 
+        operational efficiency over unnecessary complexity.
       </p>
     </div>
   </section>
@@ -98,77 +88,15 @@ import SkillBadges from '../components/SkillBadges.astro';
       <h3 class="font-semibold text-gray-900 group-hover:text-indigo-600 transition-colors">Talks</h3>
       <p class="text-sm text-gray-500 mt-1">Conferences & workshops</p>
     </a>
+    <a href="/technologies" class="card hover:border-indigo-300 hover:shadow-md transition-all group">
+      <div class="text-2xl mb-2">🔧</div>
+      <h3 class="font-semibold text-gray-900 group-hover:text-indigo-600 transition-colors">Technologies</h3>
+      <p class="text-sm text-gray-500 mt-1">My technical stack</p>
+    </a>
     <a href="/cv" class="card hover:border-indigo-300 hover:shadow-md transition-all group">
       <div class="text-2xl mb-2">📄</div>
       <h3 class="font-semibold text-gray-900 group-hover:text-indigo-600 transition-colors">CV</h3>
       <p class="text-sm text-gray-500 mt-1">Recruiter-friendly summary</p>
     </a>
-  </section>
-
-  <!-- Skills -->
-  <SkillBadges />
-
-  <!-- What I like -->
-  <section class="py-8">
-    <h2 class="section-title">🙂 What do I like?</h2>
-    <div class="card">
-      <ul class="space-y-3 text-gray-700">
-        <li class="flex items-start gap-3">
-          <span class="text-xl">🐍</span>
-          <span>I'm good at <strong>Python</strong> — it's my preferred programming language.</span>
-        </li>
-        <li class="flex items-start gap-3">
-          <span class="text-xl">🐋</span>
-          <span>I like using <strong>Docker</strong> from personal projects to production.</span>
-        </li>
-        <li class="flex items-start gap-3">
-          <span class="text-xl">🦾</span>
-          <span>I love to investigate about <strong>AI</strong> and <strong>Data</strong>.</span>
-        </li>
-        <li class="flex items-start gap-3">
-          <span class="text-xl">👷</span>
-          <span>I like to automate development processes (<strong>CI/CD</strong>).</span>
-        </li>
-        <li class="flex items-start gap-3">
-          <span class="text-xl">🧠</span>
-          <span>
-            I'm co-founder of the{' '}
-            <a href="https://twitter.com/aimalaga" target="_blank" rel="noopener noreferrer" class="text-indigo-600 hover:underline font-medium">
-              Malaga Association of Artificial Intelligence
-            </a>.
-          </span>
-        </li>
-      </ul>
-    </div>
-  </section>
-
-  <!-- Find me -->
-  <section class="py-8">
-    <h2 class="section-title">🔍 Where can you find me?</h2>
-    <div class="card">
-      <ul class="space-y-3 text-gray-700">
-        <li class="flex items-center gap-3">
-          <span class="text-xl">🐦</span>
-          <span>
-            <strong>Twitter</strong>:{' '}
-            <a href="https://twitter.com/aimatesanz" target="_blank" rel="noopener noreferrer" class="text-indigo-600 hover:underline">@AIMatesanz</a>
-          </span>
-        </li>
-        <li class="flex items-center gap-3">
-          <span class="text-xl">💻</span>
-          <span>
-            <strong>GitHub</strong>:{' '}
-            <a href="https://github.com/Matesanz" target="_blank" rel="noopener noreferrer" class="text-indigo-600 hover:underline">@Matesanz</a>
-          </span>
-        </li>
-        <li class="flex items-center gap-3">
-          <span class="text-xl">💼</span>
-          <span>
-            <strong>LinkedIn</strong>:{' '}
-            <a href="https://www.linkedin.com/in/aimatesanz/" target="_blank" rel="noopener noreferrer" class="text-indigo-600 hover:underline">@Matesanz</a>
-          </span>
-        </li>
-      </ul>
-    </div>
   </section>
 </BaseLayout>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -1,11 +1,10 @@
 ---
 import BaseLayout from '../layouts/BaseLayout.astro';
-import SkillBadges from '../components/SkillBadges.astro';
 ---
 
 <BaseLayout
   title="Andrés Matesanz — AI & Automation Engineer"
-  description="AI & Automation Engineer at Labster specializing in product-first solutions, data automation, and efficient AI integration."
+  description="AI & Automation Engineer with a product-first mindset. I solve real problems with the simplest technology that works — and use AI only when it genuinely fits."
 >
   <!-- Hero Section -->
   <section class="py-12 text-center">
@@ -23,7 +22,7 @@ import SkillBadges from '../components/SkillBadges.astro';
           👋 Hi, I'm Andrés Matesanz
         </h1>
         <p class="text-xl text-indigo-600 font-medium">AI & Automation Engineer</p>
-        <p class="text-gray-500 mt-1">Product First · Automation · AI · Python</p>
+        <p class="text-gray-500 mt-1">Computer Vision · Automation · Low-Code · MLOps</p>
       </div>
 
       <!-- Social buttons -->
@@ -66,13 +65,20 @@ import SkillBadges from '../components/SkillBadges.astro';
   </section>
 
   <!-- About Section -->
-  <section class="py-4">
-    <div class="card p-5">
-      <p class="text-gray-700 leading-relaxed text-base">
-        I am an <strong>AI & Automation Engineer</strong> building at <strong>Labster</strong>. 
-        I believe technology is a tool, not the goal. I solve business problems 
-        through <strong>AI & Automation</strong> when it makes sense, prioritizing impact and 
-        efficiency over complexity.
+  <section class="py-6">
+    <div class="card">
+      <p class="text-gray-700 leading-relaxed text-lg">
+        I'm an <strong>AI & Automation Engineer</strong> with a product-first mindset. My job is to
+        understand the problem my users or stakeholders are actually facing — then apply
+        <strong>the simplest technology that solves it</strong>. Not the most impressive one.
+        Sometimes that's a three-node automation workflow. Sometimes it's a custom-trained
+        computer vision model. The tool follows the problem, never the other way around.
+      </p>
+      <p class="text-gray-700 leading-relaxed text-lg mt-4">
+        Yes, you'll see <strong>AI all over this site</strong> — because it genuinely fits many of
+        the problems I work on. But I reach for it only when it does. I care far more about
+        <strong>shipping working solutions</strong> that create real value than chasing the latest
+        model release. Pragmatism over hype, always.
       </p>
     </div>
   </section>

--- a/src/pages/projects.astro
+++ b/src/pages/projects.astro
@@ -1,0 +1,86 @@
+---
+import BaseLayout from '../layouts/BaseLayout.astro';
+import { projects } from '../data/projects';
+
+// Group labels for the jump-links bar, in display order
+const jumpGroups = [
+  { id: 'labster-automation',          label: '🧪 Labster' },
+  { id: 'video-movement-prediction',   label: '🧑‍💻 Freelance' },
+  { id: 'santander-ai-mvp',            label: '🤖 SNGULAR' },
+  { id: 'codespace-bootcamp',          label: '🎓 Codespace' },
+  { id: 'aeorum-drone-cv',             label: '🚁 Aeorum' },
+  { id: 'dias2p-streetqr',             label: '🧑‍🔬 Univ. Malaga' },
+  { id: 'monkeat-pwa',                 label: '🕵️ Monkeat' },
+  { id: 'mri-superresolution',         label: '🧪 Side Projects' },
+];
+---
+
+<BaseLayout
+  title="Projects — Andrés Matesanz"
+  description="Projects by Andrés Matesanz: AI automation, computer vision, data engineering and more."
+>
+  <h1 class="text-3xl font-bold text-gray-900 mb-2">📂 Projects</h1>
+  <p class="text-gray-500 mb-10">
+    Everything I've built — professional, freelance and personal. Each project links back to the
+    company or role it belongs to.
+  </p>
+
+  <!-- Jump links -->
+  <div class="flex flex-wrap gap-2 mb-10">
+    {jumpGroups.map(g => (
+      <a href={`#${g.id}`} class="btn-outline text-xs px-3 py-1.5">{g.label}</a>
+    ))}
+  </div>
+
+  <!-- Project cards — flat list, newest first -->
+  <div class="space-y-6">
+    {projects.map(project => (
+      <div id={project.id} class="card scroll-mt-20">
+
+        <!-- Header row -->
+        <div class="flex flex-col sm:flex-row sm:items-start sm:justify-between gap-1 mb-2">
+          <h2 class="text-lg font-semibold text-gray-900">
+            {project.emoji} {project.title}
+          </h2>
+          <span class="text-sm text-indigo-600 font-medium whitespace-nowrap">{project.period}</span>
+        </div>
+
+        <!-- Company tag -->
+        <div class="mb-3">
+          {project.companyId !== 'side' ? (
+            <a
+              href={`/experience#${project.companyId}`}
+              class="inline-flex items-center gap-1 text-xs font-medium px-2.5 py-1 rounded-full bg-indigo-50 text-indigo-700 hover:bg-indigo-100 transition-colors"
+            >
+              {project.company} ↗
+            </a>
+          ) : (
+            <span class="inline-flex items-center gap-1 text-xs font-medium px-2.5 py-1 rounded-full bg-gray-100 text-gray-600">
+              🧪 Side Project
+            </span>
+          )}
+        </div>
+
+        <!-- Description -->
+        <p class="text-sm text-gray-700 leading-relaxed mb-4">{project.description}</p>
+
+        <!-- Links -->
+        {project.links && project.links.length > 0 && (
+          <div class="flex flex-wrap gap-2">
+            {project.links.map(link => (
+              <a
+                href={link.url}
+                target="_blank"
+                rel="noopener noreferrer"
+                class={link.type === 'primary' ? 'btn-primary text-xs px-3 py-1.5' : 'btn-outline text-xs px-3 py-1.5'}
+              >
+                {link.label}
+              </a>
+            ))}
+          </div>
+        )}
+
+      </div>
+    ))}
+  </div>
+</BaseLayout>

--- a/src/pages/projects.astro
+++ b/src/pages/projects.astro
@@ -4,14 +4,15 @@ import { projects } from '../data/projects';
 
 // Group labels for the jump-links bar, in display order
 const jumpGroups = [
-  { id: 'labster-automation',          label: '🧪 Labster' },
-  { id: 'video-movement-prediction',   label: '🧑‍💻 Freelance' },
-  { id: 'santander-ai-mvp',            label: '🤖 SNGULAR' },
-  { id: 'codespace-bootcamp',          label: '🎓 Codespace' },
-  { id: 'aeorum-drone-cv',             label: '🚁 Aeorum' },
-  { id: 'dias2p-streetqr',             label: '🧑‍🔬 Univ. Malaga' },
-  { id: 'monkeat-pwa',                 label: '🕵️ Monkeat' },
-  { id: 'mri-superresolution',         label: '🧪 Side Projects' },
+  { id: 'labster-accessibility-ai',    label: '📅 2026' },
+  { id: 'labster-automation',          label: '📅 2025' },
+  { id: 'uve-valuation-ai',            label: '📅 2024' },
+  { id: 'junction-2023-rag',           label: '📅 2023' },
+  { id: 'face-expression-recognition', label: '📅 2022' },
+  { id: 'pet-detector',                label: '📅 2021' },
+  { id: 'aeorum-orthophotos',          label: '📅 2020' },
+  { id: 'monkeat-pwa',                 label: '📅 2019' },
+  { id: 'malaga-ai-association',       label: '📅 2018' },
 ];
 ---
 
@@ -35,52 +36,73 @@ const jumpGroups = [
   <!-- Project cards — flat list, newest first -->
   <div class="space-y-6">
     {projects.map(project => (
-      <div id={project.id} class="card scroll-mt-20">
+      <details id={project.id} class="group card scroll-mt-20 overflow-hidden [&_summary::-webkit-details-marker]:hidden">
+        <summary class="flex flex-col gap-2 cursor-pointer list-none">
+          <!-- Header row -->
+          <div class="flex flex-col sm:flex-row sm:items-start sm:justify-between gap-1">
+            <h2 class="text-lg font-semibold text-gray-900 group-open:text-indigo-600 transition-colors">
+              {project.emoji} {project.title}
+            </h2>
+            <div class="flex items-center gap-3">
+              <span class="text-sm text-indigo-600 font-medium whitespace-nowrap">{project.period}</span>
+              <svg 
+                xmlns="http://www.w3.org/2000/svg" 
+                class="h-5 w-5 text-gray-400 group-open:rotate-180 transition-transform" 
+                viewBox="0 0 20 20" 
+                fill="currentColor"
+              >
+                <path fill-rule="evenodd" d="M5.293 7.293a1 1 0 011.414 0L10 10.586l3.293-3.293a1 1 0 111.414 1.414l-4 4a1 1 0 01-1.414 0l-4-4a1 1 0 010-1.414z" clip-rule="evenodd" />
+              </svg>
+            </div>
+          </div>
 
-        <!-- Header row -->
-        <div class="flex flex-col sm:flex-row sm:items-start sm:justify-between gap-1 mb-2">
-          <h2 class="text-lg font-semibold text-gray-900">
-            {project.emoji} {project.title}
-          </h2>
-          <span class="text-sm text-indigo-600 font-medium whitespace-nowrap">{project.period}</span>
-        </div>
+          <!-- Company tag -->
+          <div class="flex items-center gap-2">
+            {project.companyId !== 'side' ? (
+              <span class="inline-flex items-center gap-1 text-xs font-medium px-2.5 py-1 rounded-full bg-indigo-50 text-indigo-700">
+                {project.company}
+              </span>
+            ) : (
+              <span class="inline-flex items-center gap-1 text-xs font-medium px-2.5 py-1 rounded-full bg-gray-100 text-gray-600">
+                🧪 Side Project
+              </span>
+            )}
+            <span class="text-xs text-gray-400 font-normal">Click to expand description</span>
+          </div>
+        </summary>
 
-        <!-- Company tag -->
-        <div class="mb-3">
-          {project.companyId !== 'side' ? (
-            <a
-              href={`/experience#${project.companyId}`}
-              class="inline-flex items-center gap-1 text-xs font-medium px-2.5 py-1 rounded-full bg-indigo-50 text-indigo-700 hover:bg-indigo-100 transition-colors"
-            >
-              {project.company} ↗
-            </a>
-          ) : (
-            <span class="inline-flex items-center gap-1 text-xs font-medium px-2.5 py-1 rounded-full bg-gray-100 text-gray-600">
-              🧪 Side Project
-            </span>
+        <div class="mt-4 pt-4 border-t border-gray-100">
+          <!-- Description -->
+          <p class="text-sm text-gray-700 leading-relaxed mb-4">{project.description}</p>
+
+          <!-- Links -->
+          {project.links && project.links.length > 0 && (
+            <div class="flex flex-wrap gap-2">
+              {project.links.map(link => (
+                <a
+                  href={link.url}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  class={link.type === 'primary' ? 'btn-primary text-xs px-3 py-1.5' : 'btn-outline text-xs px-3 py-1.5'}
+                >
+                  {link.label}
+                </a>
+              ))}
+            </div>
+          )}
+          
+          {project.companyId !== 'side' && (
+            <div class="mt-4">
+              <a
+                href={`/experience#${project.companyId}`}
+                class="text-xs text-indigo-500 hover:text-indigo-700 font-medium flex items-center gap-1"
+              >
+                View in Experience ↗
+              </a>
+            </div>
           )}
         </div>
-
-        <!-- Description -->
-        <p class="text-sm text-gray-700 leading-relaxed mb-4">{project.description}</p>
-
-        <!-- Links -->
-        {project.links && project.links.length > 0 && (
-          <div class="flex flex-wrap gap-2">
-            {project.links.map(link => (
-              <a
-                href={link.url}
-                target="_blank"
-                rel="noopener noreferrer"
-                class={link.type === 'primary' ? 'btn-primary text-xs px-3 py-1.5' : 'btn-outline text-xs px-3 py-1.5'}
-              >
-                {link.label}
-              </a>
-            ))}
-          </div>
-        )}
-
-      </div>
+      </details>
     ))}
   </div>
 </BaseLayout>

--- a/src/pages/talks.astro
+++ b/src/pages/talks.astro
@@ -12,7 +12,60 @@ import YouTubeEmbed from '../components/YouTubeEmbed.astro';
 
   <div class="space-y-8">
 
-    <!-- Talk 1: Devcontainers -->
+    <!-- Talk 1: PyData Granada 2024 -->
+    <div class="card">
+      <div class="flex flex-col sm:flex-row sm:items-start sm:justify-between gap-1 mb-3">
+        <h2 class="text-xl font-semibold text-gray-900">🤖 IA No Code: Creando un producto de IA en 30 minutos</h2>
+        <span class="text-sm text-indigo-600 font-medium whitespace-nowrap">2024-11-21 — PyData Granada</span>
+      </div>
+      <p class="text-gray-700 leading-relaxed text-sm mb-4">
+        Live-built a fully functional generative AI product in <strong>30 minutes, zero lines of code</strong> — a custom avatar bot
+        using <strong>Telegram + Make.com + HuggingFace Spaces</strong>. Part of the 9th PyData Granada Meetup, held within the
+        II Congreso de Inteligencia Artificial de Andalucía. The talk challenges the assumption that shipping AI products
+        requires deep technical knowledge: with the right low-code tools, anyone can prototype fast.
+      </p>
+      <div class="flex flex-wrap gap-2">
+        <a href="https://www.meetup.com/es-ES/pydatagrx/events/304163686/" target="_blank" rel="noopener noreferrer" class="btn-outline text-xs px-3 py-1.5">
+          📅 Event Page
+        </a>
+      </div>
+    </div>
+
+    <!-- Talk 2: TechFest 2024 -->
+    <div class="card">
+      <div class="flex flex-col sm:flex-row sm:items-start sm:justify-between gap-1 mb-3">
+        <h2 class="text-xl font-semibold text-gray-900">🏀 ¡Triple sobre la bocina! El apasionante mundo del Computer Vision 3D</h2>
+        <span class="text-sm text-indigo-600 font-medium whitespace-nowrap">2024-03-14 — TechFest</span>
+      </div>
+      <p class="text-gray-700 leading-relaxed text-sm mb-4">
+        A live experiment at <strong>TechFest 2024</strong>, one of Spain's most prominent tech festivals. I tracked a real
+        basketball in 3D using <strong>locally-running computer vision models</strong> and visualised everything in real-time
+        with <strong>Rerun</strong> — no cloud, no pre-recorded video, all on-device. The audience saw the 3D reconstruction
+        appear on screen as the ball flew through the air. One of the talks I'm most proud of.
+      </p>
+      <YouTubeEmbed id="v_vFJkKw9kU" title="¡Triple sobre la bocina! Computer Vision 3D — TechFest 2024" />
+    </div>
+
+    <!-- Talk 3: Málaga AI 2023 -->
+    <div class="card">
+      <div class="flex flex-col sm:flex-row sm:items-start sm:justify-between gap-1 mb-3">
+        <h2 class="text-xl font-semibold text-gray-900">🎯 Computer Vision 3D + Networking</h2>
+        <span class="text-sm text-indigo-600 font-medium whitespace-nowrap">2023-11-15 — Málaga AI</span>
+      </div>
+      <p class="text-gray-700 leading-relaxed text-sm mb-4">
+        The first public run of the <strong>3D computer vision basketball tracking demo</strong>, presented at the
+        Spain AI Málaga chapter meetup. Same concept that later became the TechFest 2024 talk — live multi-camera
+        3D reconstruction of a moving ball, shown on screen in real-time.
+      </p>
+      <div class="flex flex-wrap gap-2 mb-4">
+        <a href="https://www.eventbrite.es/e/entradas-charla-presencial-de-malaga-ai-computer-vision-3d-networking-743439265857" target="_blank" rel="noopener noreferrer" class="btn-outline text-xs px-3 py-1.5">
+          📅 Event Page
+        </a>
+      </div>
+      <p class="text-xs text-gray-400 italic">Video not recorded for this session.</p>
+    </div>
+
+    <!-- Talk 4: Devcontainers -->
     <div class="card">
       <div class="flex flex-col sm:flex-row sm:items-start sm:justify-between gap-1 mb-3">
         <h2 class="text-xl font-semibold text-gray-900">🐋 Intro to Devcontainers</h2>
@@ -24,12 +77,10 @@ import YouTubeEmbed from '../components/YouTubeEmbed.astro';
         colleagues to start developing in the same repo. Since I discovered this tool I've been using it for every
         single project. I gave this talk to my colleagues at Sngular 🎉 and they loved it 💙.
       </p>
-      <div class="mt-4 p-3 bg-amber-50 border border-amber-200 rounded-lg text-sm text-amber-800">
-        ⚠️ Video not yet available.
-      </div>
+      <p class="text-xs text-gray-400 italic mt-4">No recording available for this session.</p>
     </div>
 
-    <!-- Talk 2: Face Expressions -->
+    <!-- Talk 5: Face Expressions -->
     <div class="card">
       <div class="flex flex-col sm:flex-row sm:items-start sm:justify-between gap-1 mb-3">
         <h2 class="text-xl font-semibold text-gray-900">😄 Analyzing Face Expressions</h2>
@@ -60,7 +111,7 @@ import YouTubeEmbed from '../components/YouTubeEmbed.astro';
       </div>
     </div>
 
-    <!-- Talk 3: RL Bootcamp -->
+    <!-- Talk 6: RL Bootcamp -->
     <div class="card">
       <div class="flex flex-col sm:flex-row sm:items-start sm:justify-between gap-1 mb-3">
         <h2 class="text-xl font-semibold text-gray-900">🤖 Reinforcement Learning and Python Bootcamp</h2>
@@ -86,7 +137,7 @@ import YouTubeEmbed from '../components/YouTubeEmbed.astro';
       </div>
     </div>
 
-    <!-- Talk 4: Pet Detector -->
+    <!-- Talk 7: Pet Detector -->
     <div class="card">
       <div class="flex flex-col sm:flex-row sm:items-start sm:justify-between gap-1 mb-3">
         <h2 class="text-xl font-semibold text-gray-900">🐈 Detecting your Pet using AI</h2>
@@ -116,7 +167,7 @@ import YouTubeEmbed from '../components/YouTubeEmbed.astro';
       </div>
     </div>
 
-    <!-- Talk 5: Intro to Python & RL -->
+    <!-- Talk 8: Intro to Python & RL -->
     <div class="card">
       <div class="flex flex-col sm:flex-row sm:items-start sm:justify-between gap-1 mb-3">
         <h2 class="text-xl font-semibold text-gray-900">🤖 Intro to Python and Reinforcement Learning</h2>
@@ -139,7 +190,7 @@ import YouTubeEmbed from '../components/YouTubeEmbed.astro';
       </blockquote>
     </div>
 
-    <!-- Talk 6: GANs - CoronaConf -->
+    <!-- Talk 9: GANs - CoronaConf -->
     <div class="card">
       <div class="flex flex-col sm:flex-row sm:items-start sm:justify-between gap-1 mb-3">
         <h2 class="text-xl font-semibold text-gray-900">🧙 Intro to Generative Adversarial Networks</h2>
@@ -157,7 +208,7 @@ import YouTubeEmbed from '../components/YouTubeEmbed.astro';
       <YouTubeEmbed id="aQtt2eKE2Bc" title="Intro to GANs — CoronaConf 2020" />
     </div>
 
-    <!-- Talk 7: Artificial Creativity -->
+    <!-- Talk 10: Artificial Creativity -->
     <div class="card">
       <div class="flex flex-col sm:flex-row sm:items-start sm:justify-between gap-1 mb-3">
         <h2 class="text-xl font-semibold text-gray-900">🖌️ Intro to Artificial Creativity</h2>
@@ -174,7 +225,7 @@ import YouTubeEmbed from '../components/YouTubeEmbed.astro';
       </blockquote>
     </div>
 
-    <!-- Talk 8: I See Nets -->
+    <!-- Talk 11: I See Nets -->
     <div class="card">
       <div class="flex flex-col sm:flex-row sm:items-start sm:justify-between gap-1 mb-3">
         <h2 class="text-xl font-semibold text-gray-900">👁️ I See Nets — CNN Architectures</h2>

--- a/src/pages/talks.astro
+++ b/src/pages/talks.astro
@@ -15,7 +15,7 @@ import YouTubeEmbed from '../components/YouTubeEmbed.astro';
     <!-- Talk 1: PyData Granada 2024 -->
     <div class="card">
       <div class="flex flex-col sm:flex-row sm:items-start sm:justify-between gap-1 mb-3">
-        <h2 class="text-xl font-semibold text-gray-900">🤖 IA No Code: Creando un producto de IA en 30 minutos</h2>
+        <h2 class="text-xl font-semibold text-gray-900">🤖 No-Code AI: Building an AI Product in 30 Minutes</h2>
         <span class="text-sm text-indigo-600 font-medium whitespace-nowrap">2024-11-21 — PyData Granada</span>
       </div>
       <p class="text-gray-700 leading-relaxed text-sm mb-4">
@@ -34,7 +34,7 @@ import YouTubeEmbed from '../components/YouTubeEmbed.astro';
     <!-- Talk 2: TechFest 2024 -->
     <div class="card">
       <div class="flex flex-col sm:flex-row sm:items-start sm:justify-between gap-1 mb-3">
-        <h2 class="text-xl font-semibold text-gray-900">🏀 ¡Triple sobre la bocina! El apasionante mundo del Computer Vision 3D</h2>
+        <h2 class="text-xl font-semibold text-gray-900">🏀 Buzzer Beater! The Fascinating World of 3D Computer Vision</h2>
         <span class="text-sm text-indigo-600 font-medium whitespace-nowrap">2024-03-14 — TechFest</span>
       </div>
       <p class="text-gray-700 leading-relaxed text-sm mb-4">
@@ -43,7 +43,7 @@ import YouTubeEmbed from '../components/YouTubeEmbed.astro';
         with <strong>Rerun</strong> — no cloud, no pre-recorded video, all on-device. The audience saw the 3D reconstruction
         appear on screen as the ball flew through the air. One of the talks I'm most proud of.
       </p>
-      <YouTubeEmbed id="v_vFJkKw9kU" title="¡Triple sobre la bocina! Computer Vision 3D — TechFest 2024" />
+      <YouTubeEmbed id="v_vFJkKw9kU" title="Buzzer Beater! 3D Computer Vision — TechFest 2024" />
     </div>
 
     <!-- Talk 3: Málaga AI 2023 -->

--- a/src/pages/technologies.astro
+++ b/src/pages/technologies.astro
@@ -1,0 +1,20 @@
+---
+import BaseLayout from '../layouts/BaseLayout.astro';
+import SkillBadges from '../components/SkillBadges.astro';
+---
+
+<BaseLayout
+  title="Technologies — Andrés Matesanz"
+  description="Tools, languages, and frameworks I use for AI, Automation, and Software Engineering."
+>
+  <div class="space-y-8">
+    <header>
+      <h1 class="text-3xl font-bold text-gray-900">Technologies</h1>
+      <p class="text-gray-600 mt-2">
+        A comprehensive look at my technical stack, from AI research to production-ready automation.
+      </p>
+    </header>
+
+    <SkillBadges />
+  </div>
+</BaseLayout>

--- a/src/pages/technologies.astro
+++ b/src/pages/technologies.astro
@@ -5,16 +5,12 @@ import SkillBadges from '../components/SkillBadges.astro';
 
 <BaseLayout
   title="Technologies — Andrés Matesanz"
-  description="Tools, languages, and frameworks I use for AI, Automation, and Software Engineering."
+  description="Technologies and tools used by Andrés Matesanz: Python, PyTorch, Docker, ROS, n8n, and more."
 >
-  <div class="space-y-8">
-    <header>
-      <h1 class="text-3xl font-bold text-gray-900">Technologies</h1>
-      <p class="text-gray-600 mt-2">
-        A comprehensive look at my technical stack, from AI research to production-ready automation.
-      </p>
-    </header>
+  <h1 class="text-3xl font-bold text-gray-900 mb-2">🔧 Technologies</h1>
+  <p class="text-gray-500 mb-10">
+    Tools and technologies I reach for when they're the right fit for the job.
+  </p>
 
-    <SkillBadges />
-  </div>
+  <SkillBadges />
 </BaseLayout>


### PR DESCRIPTION
- experience.astro: full rewrite with 7 entries (Labster, Codespace, SNGULAR with 5 sub-projects, Aeorum corrected dates, UMA, Monkeat) plus a new Freelance section (video movement prediction model)
- talks.astro: add 3 new talks (TechFest 2024 with YouTube embed, PyData Granada Nov 2024, Málaga AI Nov 2023); fix devcontainers amber warning to a neutral italic note
- cv.astro: new recruiter-focused single-page CV at /cv — bio with product-impact framing (90% Labster efficiency gain), compact experience timeline, education, SkillBadges, selected talks, LinkedIn CTA; print-friendly via print:hidden utilities
- Nav.astro: add CV link to navigation
- index.astro: add CV quick-nav card; grid updated to 2×2 / 4-col