### PR TITLE
fix: highlight active nav link on all pages

### DIFF
--- a/src/components/Nav.astro
+++ b/src/components/Nav.astro
@@ -9,7 +9,7 @@ const navLinks = [
   { href: '/cv', label: 'CV' },
 ];
 
-const pathname = Astro.url.pathname;
+const pathname = Astro.url.pathname.replace(/\/$/, '') || '/';
 ---
 
 <nav class="sticky top-0 z-50 bg-white/90 backdrop-blur border-b border-gray-200">


### PR DESCRIPTION
Astro's static build produces trailing-slash URLs (e.g. /experience/) but nav hrefs are defined without them, causing the active check to only match the root path. Strip trailing slash before comparing so every section highlights correctly when visited.