### PR TITLE
Embed YouTube video for Intro to Python and RL talk

### DIFF
--- a/src/pages/talks.astro
+++ b/src/pages/talks.astro
@@ -180,11 +180,7 @@ import YouTubeEmbed from '../components/YouTubeEmbed.astro';
         Thanks to Covid, we moved it online, reaching <strong>up to 200 students per class</strong>. 🎉
         Students trained an RL agent using OpenAI Gym + TensorFlow to solve the CartPole problem.
       </p>
-      <div class="flex flex-wrap gap-2 mb-4">
-        <a href="https://www.youtube.com/watch?v=yzJsAr5MxtM&t=14s" target="_blank" rel="noopener noreferrer" class="btn-primary text-xs px-3 py-1.5">
-          ▶ Watch Video (🇪🇸)
-        </a>
-      </div>
+      <YouTubeEmbed id="yzJsAr5MxtM" title="Intro to Python and Reinforcement Learning — Spain AI 2020" />
       <blockquote class="twitter-tweet" data-lang="es">
         <a href="https://twitter.com/AIMatesanz/status/1244576579713470464"></a>
       </blockquote>


### PR DESCRIPTION
Replace the Watch Video button link with a YouTubeEmbed component
for the "Intro to Python and Reinforcement Learning" talk, consistent
with other talks that have embedded video players.

https://claude.ai/code/session_017unwdnZcwJykWNdTiaG2t3