### PR TITLE
Embed YouTube video for Detecting your Pet using AI talk

### DIFF
--- a/src/pages/talks.astro
+++ b/src/pages/talks.astro
@@ -150,13 +150,11 @@ import YouTubeEmbed from '../components/YouTubeEmbed.astro';
         using the <strong>mAP metric</strong>.
       </p>
       <div class="flex flex-wrap gap-2 mb-4">
-        <a href="https://www.youtube.com/watch?v=Fr8t0SuHASA" target="_blank" rel="noopener noreferrer" class="btn-primary text-xs px-3 py-1.5">
-          ▶ Watch Video (🇪🇸)
-        </a>
         <a href="https://github.com/Matesanz/pet-detector" target="_blank" rel="noopener noreferrer" class="btn-outline text-xs px-3 py-1.5">
           💻 Code
         </a>
       </div>
+      <YouTubeEmbed id="Fr8t0SuHASA" title="Detecting your Pet using AI — TabularConf 2021" />
       <div class="space-y-2">
         <blockquote class="twitter-tweet" data-lang="es">
           <a href="https://twitter.com/AIMatesanz/status/1355254413393350659"></a>


### PR DESCRIPTION
Replace the Watch Video button link with a YouTubeEmbed component for the "Detecting your Pet using AI" talk, consistent with the other talks that have embedded video players.