### PR TITLE
fix: correct bootcamp instructor end date

### DIFF
--- a/src/pages/cv.astro
+++ b/src/pages/cv.astro
@@ -154,7 +154,7 @@ import { getProjectsByCompany } from '../data/projects';
             <h3 class="text-base font-semibold text-gray-900">Bootcamp Instructor</h3>
             <p class="text-sm font-medium text-indigo-600">Codespace Academy</p>
           </div>
-          <span class="text-xs text-gray-500 whitespace-nowrap sm:text-right">May 2023 – Dec 2023</span>
+          <span class="text-xs text-gray-500 whitespace-nowrap sm:text-right">May 2023 – Dec 2025</span>
         </div>
         <p class="text-sm text-gray-700 leading-relaxed mt-2 mb-4">
           Full <strong>curriculum design and delivery</strong> for Machine Learning bootcamps —

--- a/src/pages/experience.astro
+++ b/src/pages/experience.astro
@@ -105,7 +105,7 @@ const freelanceProjects = getProjectsByCompany('freelance');
         title="Bootcamp Instructor"
         subtitle="Codespace Academy"
         subtitleUrl="https://codespaceacademy.com/"
-        period="May 2023 – Dec 2023"
+        period="May 2023 – Dec 2025"
       >
         <p class="text-sm text-gray-700 leading-relaxed mb-5">
           Full <strong>curriculum design and delivery</strong> for Machine Learning bootcamps —


### PR DESCRIPTION
## Summary
- Corrects the Bootcamp Instructor end date from December 2023 to December 2025 in the Experience page.
- Keeps the CV page consistent with the corrected date.

## Verification
- 
> matesanz-github-io@1.0.0 build
> astro build

20:21:26 [types] Generated 101ms
20:21:26 [build] output: "static"
20:21:26 [build] mode: "static"
20:21:26 [build] directory: /root/matesanz.github.io/dist/
20:21:26 [build] Collecting build info...
20:21:26 [build] ✓ Completed in 134ms.
20:21:26 [build] Building static entrypoints...
20:21:29 [WARN] [vite] "matchHostname", "matchPathname", "matchPort" and "matchProtocol" are imported from external module "@astrojs/internal-helpers/remote" but never used in "node_modules/astro/dist/assets/utils/index.js".
20:21:30 [vite] ✓ built in 3.70s
20:21:30 [vite] ✓ built in 25ms
20:21:30 [build] Rearranging server assets...

 generating static routes 
20:21:30   ├─ /cv/index.html (+33ms) 
20:21:30   ├─ /education/index.html (+7ms) 
20:21:30   ├─ /experience/index.html (+6ms) 
20:21:30   ├─ /projects/index.html (+12ms) 
20:21:30   ├─ /talks/index.html (+6ms) 
20:21:30   ├─ /technologies/index.html (+5ms) 
20:21:30   ├─ /index.html (+4ms) 
20:21:30 ✓ Completed in 92ms.

20:21:30 [build] ✓ Completed in 3.93s.
20:21:30 [@astrojs/sitemap] `sitemap-index.xml` created at `dist`
20:21:30 [build] 7 page(s) built in 4.08s
20:21:30 [build] Complete! passes successfully.